### PR TITLE
New nos cli subcommands and sample `system info`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: /usr/share/miniconda3/envs/nos-${{ matrix.os }}-${{ matrix.python-version }}
-          key: conda-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('conda/envs/base-cpu/env.yml') }}-${{ env.CACHE_NUMBER }}
+          key: conda-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('conda/envs/base-cpu/env.yml') }}-${{ hashFiles('pyproject.toml') }}-${{ env.CACHE_NUMBER }}
         id: cache
       - name: Install dependencies
         run: make develop-cpu

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ develop-cpu: ## Install CPU dependencies and package in developer/editable-mode
 	python -m pip install --upgrade pip
 	pip install --upgrade pip setuptools
 	pip install torch==1.13.1 torchvision==0.14.1 torchaudio==0.13.1
-	pip install --editable '.[dev,docs]'
+	pip install --editable '.[dev,test,docs]'
 	make post-install-check
 
 install: ## Install wheel package

--- a/nos/cli/README.md
+++ b/nos/cli/README.md
@@ -1,0 +1,15 @@
+# NOS CLI
+
+The `nos` CLI is the main entrypoint for running NOS from the command-line. It is designed to be easy to use and extend.
+
+Commands are organized into subcommands, which are organized into groups. For example, the `nos hub info` command is part of the `nos hub` group.
+
+## Subcommands
+
+| Section                     | Subcommand      | Description                                                                           |
+|:----------------------------|:----------------|:--------------------------------------------------------------------------------------|
+| [system](./system.py)       | `nos system`    | System-related commands to get information about your system.                         |
+| [docker](./docker.py)       | `nos docker`    | Docker-related commands to pull, initialize and run the nos docker runtime container. |
+| [hub](./hub.py)             | `nos hub`       | Hub-related commands to pull, push, and manage ML models.                             |
+| [benchmark](./benchmark.py) | `nos benchmark` | Benchmark-related commands to run benchmarks on your models.                          |
+| [serve](./serve.py)         | `nos serve`     | ML model serving related comamnds serve your ML models via a REST/gRPC API.           |

--- a/nos/cli/benchmark.py
+++ b/nos/cli/benchmark.py
@@ -1,0 +1,4 @@
+import typer
+
+
+benchmark_cli = typer.Typer(name="benchmark", help="NOS Benchmark CLI.", no_args_is_help=True)

--- a/nos/cli/cli.py
+++ b/nos/cli/cli.py
@@ -1,49 +1,18 @@
-from pathlib import Path
-
 import typer
 
-from nos.constants import NOS_MODELS_DIR
+from nos.cli.benchmark import benchmark_cli
+from nos.cli.docker import docker_cli
+from nos.cli.hub import hub_cli
+from nos.cli.serve import serve_cli
+from nos.cli.system import system_cli
 
 
 app_cli = typer.Typer(no_args_is_help=True)
-hub_cli = typer.Typer(name="hub", help="NOS Hub CLI.", no_args_is_help=True)
-
-# Add subcommands to app_cli
 app_cli.add_typer(hub_cli)
-
-
-DEFAULT_MODEL_CACHE_DIR = NOS_MODELS_DIR
-
-
-@hub_cli.command("download")
-def _download_hf_model(
-    model_name: str = typer.Option(..., "-m", "--model-name", help="Huggingface model name."),
-    token: str = typer.Option("", "-t", "--token", help="HF access token"),
-    output_directory: str = typer.Option(
-        DEFAULT_MODEL_CACHE_DIR,
-        "-d",
-        "--output-directory",
-        help="Download huggingface models locally.",
-    ),
-) -> None:
-    import torch
-
-    if model_name == "stabilityai/stable-diffusion-2-fp16":
-        from diffusers import StableDiffusionPipeline
-
-        output_directory = Path(output_directory) / model_name
-        output_directory.mkdir(parents=True, exist_ok=True)
-
-        print("Downloading stable-diffusion-2-fp16 model...")
-        StableDiffusionPipeline.from_pretrained(
-            "stabilityai/stable-diffusion-2-1-base",
-            revision="fp16",
-            torch_dtype=torch.float16,
-            use_auth_token=token if token != "" else True,
-        ).save_pretrained(output_directory)
-
-    else:
-        raise NotImplementedError(f"Model {model_name} not implemented.")
+app_cli.add_typer(system_cli)
+app_cli.add_typer(benchmark_cli)
+app_cli.add_typer(docker_cli)
+app_cli.add_typer(serve_cli)
 
 
 if __name__ == "__main__":

--- a/nos/cli/docker.py
+++ b/nos/cli/docker.py
@@ -1,0 +1,4 @@
+import typer
+
+
+docker_cli = typer.Typer(name="docker", help="NOS Docker CLI.", no_args_is_help=True)

--- a/nos/cli/hub.py
+++ b/nos/cli/hub.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import typer
+
+from nos.constants import NOS_MODELS_DIR
+
+
+DEFAULT_MODEL_CACHE_DIR = NOS_MODELS_DIR
+
+
+hub_cli = typer.Typer(name="hub", help="NOS Hub CLI.", no_args_is_help=True)
+
+
+@hub_cli.command("download")
+def _download_hf_model(
+    model_name: str = typer.Option(..., "-m", "--model-name", help="Huggingface model name."),
+    token: str = typer.Option("", "-t", "--token", help="HF access token"),
+    output_directory: str = typer.Option(
+        DEFAULT_MODEL_CACHE_DIR,
+        "-d",
+        "--output-directory",
+        help="Download huggingface models locally.",
+    ),
+) -> None:
+    import torch
+
+    if model_name == "stabilityai/stable-diffusion-2-fp16":
+        from diffusers import StableDiffusionPipeline
+
+        output_directory = Path(output_directory) / model_name
+        output_directory.mkdir(parents=True, exist_ok=True)
+
+        print("Downloading stable-diffusion-2-fp16 model...")
+        StableDiffusionPipeline.from_pretrained(
+            "stabilityai/stable-diffusion-2-1-base",
+            revision="fp16",
+            torch_dtype=torch.float16,
+            use_auth_token=token if token != "" else True,
+        ).save_pretrained(output_directory)
+
+    else:
+        raise NotImplementedError(f"Model {model_name} not implemented.")

--- a/nos/cli/serve.py
+++ b/nos/cli/serve.py
@@ -1,0 +1,4 @@
+import typer
+
+
+serve_cli = typer.Typer(name="serve", help="NOS Serve CLI.", no_args_is_help=True)

--- a/nos/cli/system.py
+++ b/nos/cli/system.py
@@ -1,0 +1,92 @@
+import platform
+import subprocess
+from typing import Optional
+
+import psutil
+import torch
+import typer
+from rich.console import Console
+from rich.panel import Panel
+
+import docker
+from docker.errors import APIError
+
+
+system_cli = typer.Typer(name="system", help="NOS System CLI.", no_args_is_help=True)
+console = Console()
+
+
+def sh(command: str) -> None:
+    """Execute shell command, returning stdout."""
+    try:
+        output = subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
+        return output.stdout.strip()
+    except subprocess.CalledProcessError:
+        return None
+
+
+def get_docker_version() -> Optional[str]:
+    """Get docker version, if installed."""
+    return sh("docker --version")
+
+
+def get_nvidia_smi() -> Optional[str]:
+    """Get nvidia-smi details, if installed."""
+    return sh(
+        "nvidia-smi --query-gpu=name,driver_version,pstate,pcie.link.gen.max,pcie.link.gen.current,memory.total --format=csv"
+    )
+
+
+@system_cli.command("info")
+def _system_info() -> None:
+    """Get system information (including CPU, GPU, RAM, etc.)"""
+
+    # Get system info
+    sys_info = f"""
+    System: {platform.system()}
+    Release: {platform.release()}
+    Version: {platform.version()}
+    Machine: {platform.machine()}
+    Architecture: {platform.architecture()}
+    Processor Type: {platform.processor()}
+    Python Implementation: {platform.python_implementation()}
+    CPU Count: {psutil.cpu_count()}
+    """
+    console.print(Panel(sys_info, title="System"))
+
+    # Get docker version
+    console.print(Panel(f"{get_docker_version()}", title="Docker"))
+
+    # Get nvidia-smi details
+    console.print(Panel(f"{get_nvidia_smi()}", title="nvidia-smi"))
+
+    # Check if GPU is available (via torch)
+    torch_gpu_info = ""
+    try:
+        torch_gpu_info = (
+            f"""GPU Count: {torch.cuda.device_count()}\n"""
+            f"""CUDA Version: {torch.version.cuda}\n"""
+            f"""CUDNN Version: {torch.backends.cudnn.version()}\n"""
+        )
+        if torch.cuda.is_available():
+            for i in range(torch.cuda.device_count()):
+                torch_gpu_info += "\n" if i > 0 else ""
+                torch_gpu_info += f"""[{i}] Device Properties: ({torch.cuda.get_device_properties(i)})"""
+    except ModuleNotFoundError:
+        torch_gpu_info = "GPU: None"
+    console.print(Panel(torch_gpu_info, title="Torch"))
+
+    # Check if GPU is available
+    CUDA_RUNTIME_IMAGE = "nvidia/cuda:11.0.3-runtime-ubuntu18.04"
+    nvidia_docker_gpu_info = ""
+    try:
+        # Get the output of nvidia-smi running in the container
+        client = docker.from_env()
+        container = client.containers.run(CUDA_RUNTIME_IMAGE, "nvidia-smi", detach=True)
+        for i, log in enumerate(container.logs(stream=True)):
+            nvidia_docker_gpu_info += "\n" if i > 0 else ""
+            nvidia_docker_gpu_info += f"{log.strip().decode()}"
+        container.stop()
+    except (APIError, ModuleNotFoundError):
+        nvidia_docker_gpu_info = "Failed to run nvidia-smi within docker container"
+    console.print(Panel(nvidia_docker_gpu_info, title="nvidia-smi (docker)"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,17 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
 ]
 dependencies = [
-    "av>=10.0.0",
-    "opencv-python-headless==4.6.0.66",
+    "docker>=6.0.0",
+    "psutil>=5.9.5",
     "rich>=12.5.1",
     "typer>=0.7.0",
+    # CV
+    "av>=10.0.0",
+    "opencv-python-headless==4.6.0.66",
+    # Huggingface-related packages
+    "transformers==4.21.2",
+    "diffusers==0.3.0",
+    "huggingface_hub",
 ]
 
 [project.urls]
@@ -35,11 +42,6 @@ dependencies = [
 # Development related packages
 # Note: Currently torch depdendencies are not included here as they are not
 # available on pypi and require an extra-index-url to be specified.
-test = [
-    "pytest==7.1.2",
-    "pytest-xdist==2.5.0",
-    "typeguard==2.13.3",
-]
 dev = [
     "black[jupyter]==22.3.0",
     "build==0.10.0",
@@ -47,15 +49,14 @@ dev = [
     "ruff==0.0.262",
 ]
 
-# HF transformers, diffusers related packages
-hf = [
-    "transformers==4.21.2",
-    "diffusers==0.3.0",
-    "huggingface_hub",
+test = [
+    "pytest==7.1.2",
+    "pytest-xdist==2.5.0",
+    "typeguard==2.13.3",
 ]
 
 # Documentation related packages
-doc = [
+docs = [
     "mkdocs==1.4.2",
     "mkdocs-material==9.0.14",
     "mkdocstrings==0.20.0",
@@ -91,7 +92,7 @@ select = [
     "E",  # pycodestyle errors
     "W",  # pycodestyle warnings
     "F",  # pyflakes
-    # "I",  # isort
+    "I",  # isort
     "C",  # flake8-comprehensions
     "B",  # flake8-bugbear
 ]

--- a/tests/cli/test_cli_system.py
+++ b/tests/cli/test_cli_system.py
@@ -1,0 +1,11 @@
+from typer.testing import CliRunner
+
+from nos.cli.cli import app_cli
+
+
+runner = CliRunner()
+
+
+def test_system_info():
+    result = runner.invoke(app_cli, ["system", "info"])
+    assert result.exit_code == 0


### PR DESCRIPTION
- `nos system info` - prints out system information
 - added various nos subcommands including hub, benchmark, serve, docker
## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
