### PR TITLE
Experimental ray-serve based model deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,10 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Image/video artifacts
+*.jpg
+*.jpeg
+*.png
+*.gif
+*.mp4

--- a/nos/cli/README.md
+++ b/nos/cli/README.md
@@ -29,3 +29,30 @@ nos opt optimize -m stabilityai/stable-diffusion-2
 # Serve the model for inference (WIP)
 nos serve -m stabilityai/stable-diffusion-2 --device auto
 ```
+
+
+## Getting Started
+
+To get started, install the `nos` CLI using `pip`:
+
+```bash
+pip install nos
+```
+
+## Demo
+
+Let's walk through a demo of how to use the `nos` CLI to download, optimize, and serve a model.
+
+Currently supported models include:
+ - `openai/clip-*`
+ - `stabilityai/stable-diffusion-*`
+
+Deploy the model using the following command:
+```bash
+nos serve deploy -m stabilityai/stable-diffusion-2 --min-replicas 1
+```
+
+On the client side, you can use the following command to query the model:
+```bash
+nos serve predict -m txt2img -i 'overhead imagery of trees'
+```

--- a/nos/cli/serve.py
+++ b/nos/cli/serve.py
@@ -1,4 +1,134 @@
+import time
+
+import rich.console
+import rich.status
+import rich.table
 import typer
+
+from nos.serve.client import NOS_SERVE_DEFAULT_HTTP_HOST, NOS_SERVE_DEFAULT_HTTP_PORT, SimpleClient
+from nos.serve.service import PredictionRequest, PredictionResponse
 
 
 serve_cli = typer.Typer(name="serve", help="NOS Serve CLI.", no_args_is_help=True)
+
+
+@serve_cli.command("list", help="List all deployments.")
+def _serve_list():
+    """List all deployments."""
+    from nos import serve
+
+    console = rich.console.Console()
+    table = rich.table.Table(title="Deployments")
+    table.add_column("Name", justify="left", style="cyan")
+    table.add_column("Model", justify="left", style="magenta")
+    table.add_column("Status", justify="left", style="green")
+    table.add_column("URL", justify="left", style="blue")
+
+    with rich.status.Status("Listing deployments ..."):
+        deployments = serve.list()
+        if deployments is None:
+            console.print("[red]nos serve is not running, did you run `nos serve ...`?.")
+            return
+
+        for deployment in serve.list():
+            table.add_row(deployment.name, deployment.model_name, deployment.status, deployment.url)
+
+
+@serve_cli.command("deploy", help="Create a deployment.")
+def _serve_deploy(
+    model_name: str = typer.Option(
+        ..., "-m", "--model-name", help="Name of the model to use (e.g. stabilityai/stable-diffusion-v2)."
+    ),
+    min_replicas: int = typer.Option(0, "-min", "--min-replicas", help="Minimum number of replicas to deploy."),
+    max_replicas: int = typer.Option(2, "-max", "--max-replicas", help="Maximum number of replicas to deploy."),
+    host: str = typer.Option(NOS_SERVE_DEFAULT_HTTP_HOST, "-h", "--host", help="Host of the NOS backend."),
+    port: int = typer.Option(NOS_SERVE_DEFAULT_HTTP_PORT, "-p", "--port", help="Port of the NOS backend."),
+    daemon: bool = typer.Option(False, "-d", "--daemon", help="Run the deployment in the background."),
+):
+    """Create a serve deployment from the model name.
+
+    Usage:
+        $ nos serve deploy -m stabilityai/stable-diffusion-v2
+    """
+    from nos import hub, serve
+
+    # Get the model handle by name
+    model_spec = hub.load_spec(model_name)
+
+    # Create a deployment from the model handle
+    serve.deployment(
+        model_name,
+        model_spec,
+        deployment_config={
+            "ray_actor_options": {"num_gpus": 1},
+            "autoscaling_config": {"min_replicas": min_replicas, "max_replicas": max_replicas},
+        },
+        host=host,
+        port=port,
+        daemon=daemon,
+    )
+
+
+def wait_for_backend(host: str, port: int, timeout: int = 30) -> None:
+    """Wait for the backend to be ready."""
+    client = SimpleClient(host, port)
+    with rich.status.Status("[bold green] Waiting for nos backend ...[/bold green]]") as status:
+        try:
+            client.wait(timeout=timeout)
+            status.update(f"[bold green] Connected to http://{host}:{port}.[/bold green]")
+        except TimeoutError:
+            status.update("[red] nos serve is not running, did you run `nos serve ...`?.")
+            return
+
+
+@serve_cli.command("txt2img", help="Generate an image from a text prompt.")
+def _predict_txt2img(
+    prompt: str = typer.Option(
+        ..., "-i", "--input", help="Prompt to generate image. (e.g. a cat dancing on the grass.)"
+    ),
+    img_size: int = typer.Option(512, "-s", "--img-size", help="Image size to generate."),
+    host: str = typer.Option(NOS_SERVE_DEFAULT_HTTP_HOST, "-h", "--host", help="Host of the NOS backend."),
+    port: int = typer.Option(NOS_SERVE_DEFAULT_HTTP_PORT, "-p", "--port", help="Port of the NOS backend."),
+) -> None:
+    wait_for_backend(host, port)
+
+    console = rich.console.Console()
+    client = SimpleClient(host, port)
+
+    st = time.perf_counter()
+    with rich.status.Status("[bold green] Generating image ...[/bold green]"):
+        request = PredictionRequest(
+            method="txt2img", request={"prompt": prompt, "height": img_size, "width": img_size}
+        )
+        resp = client.post("predict", json=request.dict())
+        if resp.status_code != 201:
+            console.print(f"[red] ✗ Failed to generate image (text={resp.text}).[/red]")
+            return
+        with open("output.png", "wb") as f:
+            f.write(resp.content)
+    console.print(f"[bold green] ✓ Generated image (output.png, time={time.perf_counter() - st:.3f}s) [/bold green]")
+
+
+@serve_cli.command("txt2vec", help="Generate an embedding from a text prompt.")
+def _predict_txt2vec(
+    prompt: str = typer.Option(
+        ..., "-i", "--input", help="Prompt to generate image. (e.g. a cat dancing on the grass.)"
+    ),
+    host: str = typer.Option(NOS_SERVE_DEFAULT_HTTP_HOST, "-h", "--host", help="Host of the NOS backend."),
+    port: int = typer.Option(NOS_SERVE_DEFAULT_HTTP_PORT, "-p", "--port", help="Port of the NOS backend."),
+) -> None:
+    wait_for_backend(host, port)
+
+    console = rich.console.Console()
+    client = SimpleClient(host, port)
+    st = time.perf_counter()
+    with rich.status.Status("[bold green] Generating embedding ...[/bold green]"):
+        request = PredictionRequest(method="txt2vec", request={"text": prompt})
+        response = client.post("predict", json=request.dict())
+        if response.status_code != 201:
+            console.print(f"[red] ✗ Failed to generate image (text={response.text}).[/red]")
+            return
+        response = PredictionResponse.parse_obj(response.json())
+    console.print(
+        f"[bold green] ✓ Generated embedding ({response}, time={time.perf_counter() - st:.3f}s) [/bold green]"
+    )

--- a/nos/constants.py
+++ b/nos/constants.py
@@ -6,8 +6,11 @@ NOS_HOME = Path(os.getenv("NOS_HOME", str(Path.home() / ".nos")))
 NOS_CACHE_DIR = NOS_HOME / "cache"
 NOS_MODELS_DIR = NOS_HOME / "models"
 NOS_LOG_DIR = NOS_HOME / "logs"
+NOS_TMP_DIR = NOS_HOME / "tmp"
+
 
 NOS_HOME.mkdir(parents=True, exist_ok=True)
 NOS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 NOS_MODELS_DIR.mkdir(parents=True, exist_ok=True)
 NOS_LOG_DIR.mkdir(parents=True, exist_ok=True)
+NOS_TMP_DIR.mkdir(parents=True, exist_ok=True)

--- a/nos/hub/__init__.py
+++ b/nos/hub/__init__.py
@@ -1,31 +1,21 @@
-from dataclasses import dataclass
-from functools import wraps
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type
 
+from nos.hub.config import HuggingFaceHubConfig, NosHubConfig, TorchHubConfig  # noqa: F401
+from nos.hub.spec import MethodType, ModelSpec  # noqa: F401
 from nos.logging import logger
-
-
-@dataclass(frozen=True)
-class TorchHubConfig:
-    repo: str
-    model_name: str
-    checkpoint: str = None
-
-
-@dataclass(frozen=True)
-class HuggingFaceHubConfig:
-    model_name: str
-    checkpoint: str = None
 
 
 class Hub:
     """Registry for models."""
 
     _instance: Optional["Hub"] = None
-    _configs = {}
+    """Singleton instance."""
+    _registry: Dict[str, ModelSpec] = {}
+    """Model specifications lookup for all models registered."""
 
     @classmethod
-    def get(cls) -> "Hub":
+    def get(cls: "Hub") -> "Hub":
+        """Get the singleton instance."""
         if cls._instance is None:
             cls._instance = cls()
         return cls._instance
@@ -35,54 +25,40 @@ class Hub:
         """List models in the registry."""
         if private:
             raise NotImplementedError("Private models not supported.")
-        return [v["name"] for v in cls.get()._configs.values()]
+        return [v.name for v in cls.get()._registry.values()]
 
     @classmethod
-    def load(cls, model_name: str) -> Any:
-        """Load a model from the registry."""
+    def load_spec(cls, model_name: str) -> ModelSpec:
+        """Load model spec from the registry."""
         try:
-            config = cls.get()._configs.get(model_name)
-            model_cls = config["model_cls"]
-            return model_cls()
+            return cls.get()._registry[model_name]
         except KeyError:
             raise KeyError(f"Unavailable model (name={model_name}).")
 
     @classmethod
-    def register(cls, model_name: str, model_cls: Any) -> None:
+    def load(cls, model_name: str) -> Any:
+        """Instantiate model from the registry."""
+        spec: ModelSpec = cls.load_spec(model_name)
+        return spec.cls(*spec.args, **spec.kwargs)
+
+    @classmethod
+    def register(cls, model_name: str, method: str, model_cls: Type[Any], *args, **kwargs) -> Any:
         """Model registry decorator."""
-        cls.get()._configs[model_name] = {
-            "name": model_name,
-            "model_cls": model_cls,
-        }
+        cls.get()._registry[model_name] = ModelSpec(
+            name=model_name,
+            method=MethodType[method.upper()],
+            cls=model_cls,
+            args=kwargs.pop("args", ()),
+            kwargs=kwargs.pop("kwargs", {}),
+        )
         logger.debug(f"Registered model: [name={model_name}]")
-        return model_cls
 
 
-def list(private: bool = False) -> List[Dict[str, Any]]:
-    """List models in the registry."""
-    if private:
-        raise NotImplementedError("Private models not supported.")
-    return Hub.list()
+# Alias methods
+list = Hub.list
+load = Hub.load
+register = Hub.register
+load_spec = Hub.load_spec
 
-
-def load(model_name: str) -> Any:
-    """Load a model from the registry."""
-    try:
-        return Hub.load(model_name)
-    except KeyError:
-        raise KeyError(f"Unavailable model (name={model_name}).")
-
-
-def register(model_name: str) -> Any:
-    """Model registry decorator."""
-
-    @wraps(register)
-    def _register(model_cls: Any) -> Any:
-        Hub.register(model_name, model_cls)
-        return model_cls
-
-    return _register
-
-
-# Register models
+# Register models / Populate the registry
 import nos.models  # noqa: F401, E402

--- a/nos/hub/config.py
+++ b/nos/hub/config.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NosHubConfig:
+    """NOS Hub configuration."""
+
+    namespace: str
+    """Namespace (repository, organization)."""
+    name: str
+    """Model name."""
+
+
+@dataclass(frozen=True)
+class TorchHubConfig:
+    """PyTorch Hub configuration."""
+
+    repo: str
+    """Repository name (e.g. pytorch/vision)."""
+    model_name: str
+    """Model name (e.g. resnet18)."""
+    checkpoint: str = None
+    """Checkpoint name (e.g. resnet18-5c106cde.pth)."""
+
+
+@dataclass(frozen=True)
+class HuggingFaceHubConfig:
+    """HuggingFace Hub configuration."""
+
+    model_name: str
+    """Model name (e.g. bert-base-uncased)."""
+    checkpoint: str = None
+    """Checkpoint name (e.g. bert-base-uncased-pytorch_model.bin)."""

--- a/nos/hub/spec.py
+++ b/nos/hub/spec.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Tuple
+
+
+class MethodType(Enum):
+    TXT2IMG = "txt2img"
+    TXT2VEC = "txt2vec"
+    IMG2VEC = "img2vec"
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """Model specification for the registry.
+
+    The ModelSpec defines all the relevant information for
+    the compilation, deployment, and serving of a model.
+    """
+
+    name: str
+    """Model name."""
+    method: MethodType
+    """Model method type (e.g. txt2img, txt2vec, img2vec)."""
+    cls: Any
+    """Model class instance."""
+    args: Tuple[Any, ...]
+    """Arguments to initialize the model instance."""
+    kwargs: Dict[str, Any]
+    """Keyword arguments to initialize the model instance."""
+
+    def create(self) -> Any:
+        """Create a model instance."""
+        return self.cls(*self.args, **self.kwargs)

--- a/nos/logging.py
+++ b/nos/logging.py
@@ -7,30 +7,29 @@ from .constants import NOS_LOG_DIR
 
 # Set the loguru logger level to the same level as the nos logger
 date = datetime.utcnow().strftime("%Y-%m-%d_%H%M%S")
-NOS_LOGGING_PATH = os.getenv("NOS_LOGGING_PATH", os.path.join(NOS_LOG_DIR, f"nos-{date}.log"))
-NOS_LOGGING_ROTATION = os.getenv("NOS_LOGGING_ROTATION", "100 MB")
-NOS_LOGGING_LEVEL = os.getenv("NOS_LOGGING_LEVEL", "INFO")
-LOGURU_LEVEL = os.getenv("LOGURU_LEVEL", NOS_LOGGING_LEVEL)
+LOGGING_PATH = os.getenv("NOS_LOGGING_PATH", os.path.join(NOS_LOG_DIR, f"nos-{date}.log"))
+LOGGING_ROTATION = os.getenv("NOS_LOGGING_ROTATION", "100 MB")
+LOGGING_LEVEL = os.getenv("NOS_LOGGING_LEVEL", "INFO")
 
 
-def build_logger(name: str = None):
+def build_logger(name: str = None, level: str = LOGGING_LEVEL):
     """Get a logger with the specified name"""
     from loguru import logger as _logger
 
     # Set loguru logger level to the same level as the nos logger
     # and automatically rotate big files
     if name:
-        filename = os.path.join(NOS_LOG_DIR, f"nos-{name}-{date}.log")
+        os.path.join(NOS_LOG_DIR, f"nos-{name}-{date}.log")
     else:
-        filename = NOS_LOGGING_PATH
+        pass
 
     # Remove the default logger
     _logger.remove()
     # Add a file logging handler
-    _logger.add(filename, rotation=NOS_LOGGING_ROTATION)
+    # _logger.add(filename, rotation=LOGGING_ROTATION)
     # Add a stdout/stderr logging handlers
-    _logger.add(sys.stderr, level="WARNING")
-    _logger.add(sys.stdout, level="INFO")
+    _logger.add(sys.stderr, level=LOGGING_LEVEL)
+    _logger.add(sys.stdout, level=LOGGING_LEVEL)
     return _logger
 
 

--- a/nos/models/stable_diffusion.py
+++ b/nos/models/stable_diffusion.py
@@ -53,6 +53,8 @@ class StableDiffusion2:
         num_images: int = 1,
         num_inference_steps: int = 50,
         guidance_scale: float = 7.5,
+        height: int = None,
+        width: int = None,
     ) -> List[Image.Image]:
         with torch.inference_mode():
             with torch.autocast("cuda"):
@@ -60,9 +62,21 @@ class StableDiffusion2:
                     [prompt] * num_images,
                     num_inference_steps=num_inference_steps,
                     guidance_scale=guidance_scale,
+                    height=height,
+                    width=width,
                 ).images
 
 
-@hub.register("stabilityai/stable-diffusion-2")
-def stable_diffusion_2_ddim_fp16():
-    return StableDiffusion2("stabilityai/stable-diffusion-2", scheduler="ddim", dtype=torch.float16)
+# Register the model with the hub
+# TODO (spillai): Ideally, we should do this via a decorator
+# @hub.register("stabilityai/stable-diffusion-2")
+# def stable_diffusion_2_ddim_fp16():
+#     return StableDiffusion2("stabilityai/stable-diffusion-2", scheduler="ddim", dtype=torch.float16)
+#
+hub.register(
+    "stabilityai/stable-diffusion-2",
+    "txt2img",
+    StableDiffusion2,
+    args=("stabilityai/stable-diffusion-2",),
+    kwargs={"scheduler": "ddim", "dtype": torch.float16},
+)

--- a/nos/serve/__init__.py
+++ b/nos/serve/__init__.py
@@ -1,0 +1,149 @@
+import logging
+import os
+import re
+import sys
+import time
+import traceback
+from typing import Any, Dict
+
+import ray
+from ray import serve
+from ray.serve._private import api as _private_api
+from ray.serve.exceptions import RayServeException
+from ray.serve.handle import RayServeDeploymentHandle
+from rich.console import Console
+
+from nos.hub import ModelSpec
+from nos.logging import LOGGING_LEVEL
+from nos.serve.ingress import APIIngress
+
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+
+NOS_SERVE_NS = os.getenv("NOS_SERVE_NS", "nos-dev")
+NOS_SERVE_DEFAULT_HTTP_HOST = "127.0.0.1"
+NOS_SERVE_DEFAULT_HTTP_PORT = 6169
+
+
+def get_deployment_name(model_name: str = None) -> str:
+    """Get the deployment name from the model name."""
+    return re.sub(r"[^a-zA-Z0-9_]", "_", model_name)
+
+
+def ray_init(daemon: bool = True) -> None:
+    """Initialize ray."""
+    level = getattr(logging, LOGGING_LEVEL)
+    ray.init(
+        address=os.environ.get("RAY_ADDRESS", None),
+        namespace=NOS_SERVE_NS,
+        runtime_env=None,
+        ignore_reinit_error=True,
+        configure_logging=True,
+        logging_level=LOGGING_LEVEL,
+        log_to_driver=level <= logging.INFO,
+    )
+
+
+def list():
+    """List all deployments."""
+    try:
+        return serve.list_deployments()
+    except RayServeException:
+        print("Ray Serve is not running.")
+        return None
+
+
+def deployment(
+    model_name: str,
+    model_spec: ModelSpec,
+    deployment_config: Dict[str, Dict[str, Any]] = None,
+    host: str = NOS_SERVE_DEFAULT_HTTP_HOST,
+    port: int = NOS_SERVE_DEFAULT_HTTP_PORT,
+    daemon: bool = False,
+) -> Any:
+    """Serve deployment wrapper for NOS.
+
+    This wrapper is used to create a serve deployment from a model handle.
+    The model handle is a Ray actor handle that can be used to call the model
+    remotely. The serve deployment is created using the `serve.deployment`
+    decorator.
+
+    The `nos.serve.deployment` does 2 things:
+        1. Create a serve deployment from the model_handle.
+
+            deployment = serve.deployment(
+                ray_actor_options=...,
+                autoscaling_config=...
+            )(model_handle)
+
+        2. Create an API-ingress serve deployment using the
+           deployment handle created above.
+
+            @serve.deployment(...)
+            @serve.ingress(app)
+            class APIIngress:
+                def __init__(self, model_handle) -> None:
+                    ...
+
+                @app.get("/health", status_code=status.HTTP_200_OK)
+                async def _health(self):
+                    return {"status": "ok"}
+
+                @app.post("/predict")
+                async def generate(self, request: Request):
+                    ...
+
+           entrypoint = APIIngress.bind(deployment.bind())
+
+    """
+    # Create the serve deployment from the model handle
+    model_cls = model_spec.cls
+    deployment = serve.deployment(**deployment_config)(model_cls)
+
+    # Bind the deployment to the API ingress
+    entrypoint = APIIngress.bind(deployment.bind(*model_spec.args, **model_spec.kwargs))
+
+    # Run the API ingress (optionally as a daemon)
+    deployment_name = get_deployment_name(model_name)
+
+    # Setting the runtime_env here will set defaults for the deployments.
+    console.print(f"[bold green]🔥 Deploying ... \\[name={model_name}] [/bold green]")
+    with console.status("[bold green] => Deploying ... [/bold green]") as status:
+        # Start the Ray Serve instance
+        # TODO (spillai): Add support for custom runtime-env and working-dir
+        status.update("[bold green] Initializing ray ... [/bold green]")
+        ray_init()
+
+        # Start the Ray Serve instance (in detached mode)
+        status.update("[bold green] Starting serve ... [/bold green]")
+        _private_api.serve_start(
+            detached=True,
+            http_options={"host": host, "port": port, "location": "EveryNode"},
+        )
+
+        # Run the deployment (optionally as a daemon)
+        try:
+            serve.run(entrypoint, host=host, port=port, name=deployment_name)
+            status.update(
+                f"[bold green]🚀 Deployment complete. \\[address=http://{host}:{port}, name={model_name}, id={deployment_name}] [/bold green]"
+            )
+            if not daemon:
+                while True:
+                    time.sleep(10)
+
+        # Graceful shutdown with KeyboardInterrupt
+        except KeyboardInterrupt:
+            status.update("[yellow] KeyboardInterrupt, shutting down deployment ... [/yellow]")
+            serve.shutdown()
+            sys.exit()
+
+        # Graceful shutdown with unexpected error
+        except Exception:
+            traceback.print_exc()
+            status.update(
+                "[red] ⁉️ Received unexpected error, see console logs for more details. Shutting " "down...[/red]"
+            )
+            serve.shutdown()
+            sys.exit()

--- a/nos/serve/client.py
+++ b/nos/serve/client.py
@@ -1,0 +1,37 @@
+import time
+from dataclasses import dataclass
+
+import requests
+
+
+NOS_SERVE_DEFAULT_HTTP_HOST = "127.0.0.1"
+NOS_SERVE_DEFAULT_HTTP_PORT = 6169
+
+
+@dataclass
+class SimpleClient:
+    host: str = NOS_SERVE_DEFAULT_HTTP_HOST
+    port: int = NOS_SERVE_DEFAULT_HTTP_PORT
+    timeout: int = 10
+
+    def is_healthy(self, timeout: int = 10) -> bool:
+        """Check if the server is healthy."""
+        response = requests.get(f"http://{self.host}:{self.port}/health", timeout=timeout)
+        return response.status_code == 200
+
+    def wait(self, timeout: int = 30) -> None:
+        """Wait for the server to be healthy."""
+        st = time.time()
+        while time.time() - st <= timeout:
+            try:
+                health = self.is_healthy()
+                if health:
+                    return
+            except requests.exceptions.ConnectionError:
+                time.sleep(1)
+                continue
+        raise TimeoutError("Failed to connect.")
+
+    def post(self, route: str, **kwargs) -> requests.Response:
+        """Send a POST request to the server."""
+        return requests.post(f"http://{self.host}:{self.port}/{route}", **kwargs)

--- a/nos/serve/ingress.py
+++ b/nos/serve/ingress.py
@@ -1,0 +1,67 @@
+import logging
+from io import BytesIO
+
+from fastapi import FastAPI, HTTPException, status
+from ray import serve
+from ray.serve.handle import RayServeDeploymentHandle
+from rich.console import Console
+
+from nos.hub import MethodType
+from nos.serve.service import (
+    Image2VecRequest,
+    ImageResponse,
+    PredictionRequest,
+    PredictionResponse,
+    Text2ImageRequest,
+    Text2VecRequest,
+    VecResponse,
+)
+
+
+logger = logging.getLogger(__name__)
+app = FastAPI()
+console = Console()
+
+# Create the API ingress
+# TODO (spillai): Generalize this to support multiple ingress types
+@serve.deployment(num_replicas=1, route_prefix="/")
+@serve.ingress(app)
+class APIIngress:
+    def __init__(self, handle: RayServeDeploymentHandle, predict: str = "__call__") -> None:
+        self.handle = handle
+        self.predict = predict
+
+    @app.get("/health", status_code=status.HTTP_200_OK)
+    async def _health(self):
+        return {"status": "ok"}
+
+    @app.post("/predict", response_model=PredictionResponse, status_code=status.HTTP_201_CREATED)
+    async def predict(self, request: PredictionRequest):
+        """Predict using the model."""
+        logger.error(f"Received request: {request}")
+        if request.method == MethodType.TXT2IMG.value:
+            req: Text2ImageRequest = request.request
+            if not len(req.prompt):
+                raise HTTPException(status_code=400, detail="Prompt cannot be empty.")
+            logger.info(f"Generating image with prompt: {req.prompt}")
+            response_ref = await self.handle.__call__.remote(req.prompt, height=req.height, width=req.width)
+            (image,) = await response_ref
+            file_stream = BytesIO()
+            image.save(file_stream, "PNG")
+            return PredictionResponse(response=ImageResponse.from_pil(image))
+
+        elif request.method == MethodType.TXT2VEC.value:
+            req: Text2VecRequest = request.request
+            logger.info(f"Encoding text: {req.text}")
+            response_ref = await self.handle.encode_text.remote(req.text)
+            embedding = await response_ref
+            return PredictionResponse(response=VecResponse.from_numpy(embedding.ravel()))
+
+        elif request.method == MethodType.IMG2VEC.value:
+            req: Image2VecRequest = request.request
+            response_ref = await self.handle.encode_image.remote(req.image)
+            embedding = await response_ref
+            return PredictionResponse(response=VecResponse.from_numpy(embedding.ravel()))
+
+        else:
+            raise NotImplementedError(f"Method {request.method} not implemented.")

--- a/nos/serve/service.py
+++ b/nos/serve/service.py
@@ -1,0 +1,117 @@
+import base64
+from io import BytesIO
+from typing import List, Union
+
+import numpy as np
+from PIL import Image
+from pydantic import BaseModel
+
+
+class TextRequest(BaseModel):
+    """Text generation request."""
+
+    text: str
+    """Text prompt to generate image from."""
+
+
+class TextResponse(BaseModel):
+    """Text generation response."""
+
+    text: str
+    """Generated text response."""
+
+
+class ImageRequest(BaseModel):
+    """Image request."""
+
+    image: str
+    """Base64 encoded image."""
+
+
+class ImageResponse(BaseModel):
+    """Image response."""
+
+    image: str
+    """Base64 encoded image."""
+
+    @classmethod
+    def from_pil(cls, image: Image.Image):
+        """Helper classmethod to construct ImageResponse from PIL image."""
+        file_stream = BytesIO()
+        image.save(file_stream, "PNG")
+        im_b64 = base64.b64encode(file_stream.getvalue()).decode("utf-8")
+        return ImageResponse(image=im_b64)
+
+
+class VecResponse(BaseModel):
+    """Embedding response."""
+
+    embedding: List[float]
+    """Embedding vector (fp32)."""
+
+    @classmethod
+    def from_numpy(cls, embedding: np.ndarray):
+        """Helper classmethod to construct VecResponse from numpy array."""
+        return cls(embedding=embedding.tolist())
+
+    def __repr__(self):
+        """Concise embedding repr with shape."""
+        return f"Embedding ({len(self.embedding)},)"
+
+
+class Text2ImageRequest(BaseModel):
+    """Text-to-Image generation request."""
+
+    prompt: str
+    """Text prompt to generate image from."""
+    height: int = 512
+    """Height of generated image."""
+    width: int = 512
+    """Width of generated image."""
+
+
+class Text2ImageResponse(ImageResponse):
+    """Text-to-Image generation response."""
+
+    pass
+
+
+class Text2VecRequest(TextRequest):
+    """Text-to-Embedding encoding request."""
+
+    pass
+
+
+class Text2VecResponse(VecResponse):
+    """Text-to-Embedding encoding response."""
+
+    pass
+
+
+class Image2VecRequest(ImageRequest):
+    """Image-to-Embedding encoding request."""
+
+    pass
+
+
+class Image2VecResponse(VecResponse):
+    """Image-to-Embedding encoding response."""
+
+    pass
+
+
+class PredictionRequest(BaseModel):
+    """Generic prediction request for all types of requests."""
+
+    # TODO (spillai): Map this to MethodType enum instead
+    method: str
+    """Method type."""
+    request: Union[Text2ImageRequest, Text2VecRequest, Image2VecRequest, ImageRequest, TextRequest]
+    """Request object (txt2img, txt2vec, img2vec)."""
+
+
+class PredictionResponse(BaseModel):
+    """Generic prediction response for all types of responses."""
+
+    response: Union[ImageResponse, VecResponse, TextResponse]
+    """Response object (image, embedding, text)."""

--- a/nos/test/utils.py
+++ b/nos/test/utils.py
@@ -29,7 +29,6 @@ def benchmark(test_case):
 
     These tests are triggered when `NOS_TEST_BENCHMARK=1`, and defaults to False.
     """
-    print(f"benchmark: {bool(os.getenv('NOS_TEST_BENCHMARK', default=False))}")
     return unittest.skipUnless(
         bool(os.getenv("NOS_TEST_BENCHMARK", default=False)),
         "test requires NOS_TEST_BENCHMARK=1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,14 +26,16 @@ dependencies = [
     "psutil>=5.9.5",
     "rich>=12.5.1",
     "typer>=0.7.0",
-    # CV
+    # cv-related
     "av>=10.0.0",
     "opencv-python-headless==4.6.0.66",
-    # Huggingface-related packages
+    # huggingface
     "transformers>=4.27.0",
     "diffusers>=0.14.0",
     "accelerate>=0.18.0",
     "huggingface_hub",
+    # ray
+    "ray[serve]>=2.4.0",
 ]
 
 [project.urls]

--- a/tests/cli/test_cli_serve.py
+++ b/tests/cli/test_cli_serve.py
@@ -1,0 +1,20 @@
+import pytest
+from typer.testing import CliRunner
+
+from nos.cli.cli import app_cli
+
+
+runner = CliRunner()
+
+
+@pytest.mark.skip(reason="Not yet implemented.")
+def test_cli_serve_list():
+    result = runner.invoke(app_cli, ["serve", "list"])
+    assert result.exit_code == 0
+
+
+@pytest.mark.skip(reason="Not yet implemented.")
+@pytest.mark.parametrize("model_name", ["stabilityai/stable-diffusion-v2"])
+def test_cli_serve_deploy(model_name: str):
+    result = runner.invoke(app_cli, ["serve", "deploy", "-m", model_name, "-d"])
+    assert result.exit_code == 0

--- a/tests/hub/test_hub.py
+++ b/tests/hub/test_hub.py
@@ -1,6 +1,7 @@
 import pytest
 
 from nos import hub
+from nos.hub import ModelSpec
 from nos.test.utils import PyTestGroup, requires_torch_cuda
 
 
@@ -14,8 +15,30 @@ def test_hub_load():
     models = hub.list()
     assert len(models) > 0
 
+    # Load the model with the first model name
     model = hub.load(models[0])
     assert model is not None
+
+    # Check if hub.load raises an error when the
+    # model name is invalid
+    with pytest.raises(KeyError):
+        hub.load("not-a-model-name")
+
+
+@requires_torch_cuda
+def test_hub_load_spec():
+    models = hub.list()
+    assert len(models) > 0
+
+    # Load the model spec with the first model name
+    spec = hub.load_spec(models[0])
+    assert spec is not None
+    assert isinstance(spec, ModelSpec)
+
+    # Check if hub.load_spec raises an error when the
+    # model name is invalid
+    with pytest.raises(KeyError):
+        hub.load_spec("not-a-model-name")
 
 
 @requires_torch_cuda

--- a/tests/serve/test_client.py
+++ b/tests/serve/test_client.py
@@ -1,0 +1,12 @@
+import pytest
+
+
+@pytest.mark.skip(reason="Not yet implemented.")
+def test_serve_simple_client():
+    from nos.serve import NOS_SERVE_DEFAULT_HTTP_HOST, NOS_SERVE_DEFAULT_HTTP_PORT
+    from nos.serve.client import SimpleClient
+
+    client = SimpleClient(NOS_SERVE_DEFAULT_HTTP_HOST, NOS_SERVE_DEFAULT_HTTP_PORT)
+    assert client is not None
+
+    # TODO (spillai): Test is_healthy(), wait(), and post() methods

--- a/tests/serve/test_deploy.py
+++ b/tests/serve/test_deploy.py
@@ -1,0 +1,47 @@
+import pytest  # noqa: F401
+
+from nos.test.utils import benchmark, requires_torch_cuda
+
+
+@benchmark
+@requires_torch_cuda
+def test_deployment():
+    from threading import Thread
+
+    from nos import hub, serve
+    from nos.serve.client import SimpleClient
+
+    # Create a deployment from the model handle
+    model_name = "stabilityai/stable-diffusion-2"
+    model_spec = hub.load_spec(model_name)
+
+    # Create a deployment from the model handle
+    def deploy():
+        serve.deployment(
+            model_name,
+            model_spec,
+            deployment_config={
+                "ray_actor_options": {"num_gpus": 1},
+                "autoscaling_config": {"min_replicas": 0, "max_replicas": 2},
+            },
+            daemon=True,
+        )
+
+    t = Thread(target=deploy)
+    t.start()
+
+    # Check the health of the deployment
+    client = SimpleClient()
+
+    # Wait for the deployment to be ready (30 seconds timeout)
+    # Raises TimeoutError if the deployment is not ready
+    client.wait(timeout=30)
+
+    # # Post to the deployment
+    # print("Posting to the deployment...")
+    # response = client.post("predict", json={"prompt": "a cat dancing on the grass."})
+    # assert response.status_code == 201
+
+    # Join the thread
+    print("Joining the thread...")
+    t.join()


### PR DESCRIPTION
Currently supported models include:
 - openai/clip-*
 - stabilityai/stable-diffusion-*

Deploy the model using the following command:
```
nos serve deploy -m stabilityai/stable-diffusion-2 --min-replicas 1
```

On the client side, you can use the following command to query the model:
```
nos serve predict -m txt2img -i 'overhead imagery of trees'
```

See [nos/cli/README.md](nos/cli/README.md) for more details.

<!-- Thank you for your contribution! Please review https://github.com/autonomi-ai/nos/blob/main/docs/CONTRIBUTING.md before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Summary

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
