### PR TITLE
Add ray executor as a daemon process for background serving/inference

### DIFF
--- a/nos/executors/ray.py
+++ b/nos/executors/ray.py
@@ -1,0 +1,142 @@
+import logging
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import psutil
+import ray
+import rich.console
+import rich.panel
+import rich.status
+
+from nos.constants import NOS_TMP_DIR
+from nos.logging import LOGGING_LEVEL
+
+
+logger = logging.getLogger(__name__)
+
+NOS_RAY_ADDRESS = os.environ.get("RAY_ADDRESS", "auto")
+NOS_RAY_NS = os.getenv("NOS_RAY_NS", "nos-dev")
+NOS_RAY_RUNTIME_ENV = os.getenv("NOS_RAY_ENV", None)
+
+
+@dataclass
+class RayRuntimeSpec:
+    address: str = NOS_RAY_ADDRESS
+    """Address of Ray head."""
+    namespace: str = NOS_RAY_NS
+    """Namespace for Ray runtime."""
+    runtime_env: str = NOS_RAY_RUNTIME_ENV
+    """Runtime environment for Ray runtime."""
+
+
+@dataclass
+class RayExecutor:
+    """Executor for Ray."""
+
+    _instance: "RayExecutor" = None
+    """Singleton instance of RayExecutor."""
+    spec: RayRuntimeSpec = RayRuntimeSpec()
+    """Runtime spec for Ray."""
+
+    @classmethod
+    def get(cls) -> "RayExecutor":
+        """Get the singleton instance of RayExecutor."""
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def is_initialized(self) -> bool:
+        """Check if Ray is initialized."""
+        return ray.is_initialized()
+
+    def init(self, timeout: int = 60) -> bool:
+        """Initialize Ray exector (as a daemon).
+
+        Currently, this method will first attempt to connect to an existing
+        Ray cluster (address="auto"). If it fails, it will start a Ray head
+        as a daemon, attempt to re-connect (upto a maximum of 5
+        attempts, or if timeout of 60 seconds is reached).
+
+        Args:
+            timeout: Time to wait for Ray to start. Defaults to 60 seconds.
+        """
+        level = getattr(logging, LOGGING_LEVEL)
+
+        st = time.time()
+        attempt, max_attempts = 0, 5
+
+        # Attempt to connect to an existing ray cluster.
+        # Allow upto 5 attempts, or if timeout of 60 seconds is reached.
+        console = rich.console.Console()
+        while time.time() - st <= timeout and attempt < max_attempts:
+            # Attempt to connect to an existing ray cluster in the background.
+            try:
+                with console.status("[bold green] Connecting to ray cluster ... [/bold green]"):
+                    ray.init(
+                        address=self.spec.address,
+                        namespace=self.spec.namespace,
+                        runtime_env=self.spec.runtime_env,
+                        ignore_reinit_error=True,
+                        configure_logging=True,
+                        logging_level=LOGGING_LEVEL,
+                        log_to_driver=level <= logging.INFO,
+                    )
+                    console.print(f"[bold green] ✓ Connected to ray cluster: {self.spec.address}[/bold green]")
+                return True
+            except ConnectionError:
+                # If Ray head is not running (this results in a ConnectionError),
+                # start it in a background subprocess.
+                self.start()
+                attempt += 1
+                logger.info(f"Failed to connect to Ray head. Retrying {attempt}/{max_attempts}...")
+                time.sleep(5)
+        return False
+
+    def start(self, wait: int = 5) -> Optional[int]:
+        """Start Ray head as daemon.
+
+        Args:
+            wait: Time to wait for Ray to start. Defaults to 5 seconds.
+        """
+        console = rich.console.Console()
+        with console.status("[bold green] Starting ray head (as daemon) ... [/bold green]"):
+            # Check if Ray head is already running
+            if self.pid:
+                console.print("[bold yellow] Ray head is already running. [/bold yellow]]")
+                return
+            # Start Ray head if not running
+            RAY_TMP_DIR = NOS_TMP_DIR / "ray"
+            RAY_TMP_DIR.mkdir(parents=True, exist_ok=True)
+            cmd = f"ray start --head --storage {RAY_TMP_DIR}"
+            proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            time.sleep(wait)
+            if proc.poll() != 0:
+                raise RuntimeError("Failed to start Ray.")
+            return proc.pid
+
+    def stop(self, wait: int = 5) -> Optional[int]:
+        """Stop Ray head."""
+        console = rich.console.Console()
+        with console.status("[bold green] Stopping ray head... [/bold green]"):
+            # Check if Ray head is running
+            if not self.pid:
+                console.print("[bold yellow] Ray head is not running.[/bold yellow]")
+                return
+            # Stop Ray head if pid is valid
+            cmd = "ray stop -f"
+            proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            time.sleep(wait)
+            if proc.poll() != 0:
+                raise RuntimeError("Failed to stop Ray.")
+            return proc.pid
+
+    @property
+    def pid(self) -> Optional[int]:
+        """Get PID of Ray head."""
+        for proc in psutil.process_iter(attrs=["pid", "name"]):
+            if proc.name() == "raylet":
+                return proc.pid
+        return None

--- a/tests/executors/test_ray.py
+++ b/tests/executors/test_ray.py
@@ -1,0 +1,81 @@
+import pytest
+
+from nos.executors.ray import RayExecutor
+from nos.test.utils import benchmark
+
+
+@benchmark
+def test_ray_executor():
+    """Test ray executor singleton."""
+    # Test singleton
+    executor = RayExecutor.get()
+    assert not executor.is_initialized()
+    executor_ = RayExecutor.get()
+    assert executor is executor_
+
+    # Initialize Ray executor
+    success = executor.init()
+    assert success
+    assert executor.is_initialized()
+
+    # Get raylet pid
+    pid = executor.pid
+    assert pid is not None
+    assert isinstance(pid, int)
+
+    # # Stop Ray executor
+    executor.stop()
+    pid = executor.pid
+    assert pid is None
+
+
+@benchmark
+def test_start_ray_executor():
+    """Start an executor without initializing it."""
+    executor = RayExecutor.get()
+    assert not executor.is_initialized()
+
+    # start Ray executor
+    pid = executor.start()
+    assert pid is not None
+    assert isinstance(pid, int)
+
+    # re-start Ray executor
+    # this should avoid starting a new executor gracefully
+    pid = executor.start()
+    assert pid is not None
+
+
+@benchmark
+def test_stop_ray_executor():
+    """Stop an executor without initializing it."""
+    executor = RayExecutor.get()
+    assert not executor.is_initialized()
+
+    pid = executor.stop()
+    assert pid is not None
+
+
+@pytest.mark.skip(reason="Not yet implemented.")
+def test_ray_hub_compatibility():
+    """Test hub.load_spec compatibility with RayExecutor"""
+    import ray
+
+    from nos import hub
+    from nos.hub import ModelSpec
+
+    models = hub.list()
+    assert len(models) > 0
+
+    # Create actors for each model
+    for model_name in models:
+        spec = hub.load_spec(model_name)
+        assert spec is not None
+        assert isinstance(spec, ModelSpec)
+
+        # Create actor class
+        actor_class = ray.remote(spec.cls)
+        # Create actor handle from actor class
+        actor_handle = actor_class.remote(*spec.args, **spec.kwargs)
+        assert actor_handle is not None
+        del actor_handle


### PR DESCRIPTION
- ray executor now runs under the `nos-dev` namespace
 - added tests for spawning and killing background executor
 - improved rich console prints for serving

<!-- Thank you for your contribution! Please review https://github.com/autonomi-ai/nos/blob/main/docs/CONTRIBUTING.md before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Summary

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
