### PR TITLE
Docker executor daemon for background execution of NOS jobs.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     network_mode: host
     environment:
       - NOS_HOME=/app/.nos
-      - NOS_LOGGING=DEBUG
+      - NOS_LOGGING_LEVEL=DEBUG
     volumes:
       - ~/.nos_docker:/app/.nos
       - /tmp/docker:/tmp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,5 +58,3 @@ ENV HF_HOME ${NOS_HOME}/cache/transformers
 ENV PYTHONPATH=${PYTHONPATH}:/app/${PROJECT}
 RUN echo "export PYTHONPATH=${PYTHONPATH}:/app/${PROJECT}" >> ~/.bashrc
 RUN echo "export PATH=/opt/conda/envs/${PYENV}/bin:$PATH" >> ~/.bashrc
-
-CMD ["nos" "serve"]

--- a/makefiles/Makefile.base.mk
+++ b/makefiles/Makefile.base.mk
@@ -22,27 +22,27 @@ DOCKER_CMD :=
 		${DOCKER_IMAGE_NAME}:${NOS_VERSION_TAG}-${TARGET} \
 		${DOCKER_CMD}
 
-docker-build-py3-cpu:
+docker-build-cpu:
 	make .docker-build TARGET=cpu \
 	BASE_IMAGE=python:3.8.10-slim
 
-docker-build-py3-gpu:
+docker-build-gpu:
 	make .docker-build \
 	TARGET=gpu \
 	BASE_IMAGE=nvidia/cuda:11.8.0-base-ubuntu22.04
 
 docker-build-all: \
-	docker-build-py3-cpu docker-build-py3-gpu
+	docker-build-cpu docker-build-gpu
 
-docker-compose-upd-py3-gpu: docker-build-py3-gpu
+docker-compose-upd-gpu: docker-build-gpu
 	docker compose -f docker-compose.gpu.yml up
 
-docker-test-cpu: docker-build-py3-cpu
+docker-test-cpu: docker-build-cpu
 	make .docker-run TARGET=cpu \
 	DOCKER_ARGS="-v $(shell pwd):/nos" \
 	DOCKER_CMD="make test-cpu"
 
-docker-test-gpu: docker-build-py3-gpu
+docker-test-gpu: docker-build-gpu
 	make .docker-run TARGET=gpu \
 	DOCKER_ARGS="-v $(shell pwd):/nos --gpus all" \
 	DOCKER_CMD="make test"

--- a/nos/cli/docker.py
+++ b/nos/cli/docker.py
@@ -1,4 +1,46 @@
 import typer
 
+from nos.experimental.grpc.client import NOS_GRPC_SERVER_CMD, InferenceRuntime
+from nos.logging import logger
+
 
 docker_cli = typer.Typer(name="docker", help="NOS Docker CLI.", no_args_is_help=True)
+
+
+@docker_cli.command("start", help="Start NOS inference engine.")
+def _docker_start(
+    command: str = typer.Option(NOS_GRPC_SERVER_CMD, "-c", "--command", help="Command to run in the container."),
+    gpu: bool = typer.Option(False, "--gpu", help="Start the container with GPU support."),
+):
+    """Start the NOS inference engine.
+
+    Usage:
+        $ nos docker start
+    """
+    runtime = InferenceRuntime()
+    runtime.start(detach=True, gpu=gpu)
+    logger.info("NOS inference engine started.")
+
+
+@docker_cli.command("stop", help="Stop NOS inference engine.")
+def _docker_stop():
+    """Stop the docker inference engine.
+
+    Usage:
+        $ nos docker stop
+    """
+    runtime = InferenceRuntime()
+    runtime.stop()
+
+
+@docker_cli.command("logs", help="Get NOS inference engine logs.")
+def _docker_logs():
+    """Get the docker logs of the inference engine.
+
+    Usage:
+        $ nos docker logs
+    """
+
+    runtime = InferenceRuntime()
+    logs = runtime.get_logs()
+    print(logs)

--- a/nos/constants.py
+++ b/nos/constants.py
@@ -9,6 +9,8 @@ NOS_LOG_DIR = NOS_HOME / "logs"
 NOS_TMP_DIR = NOS_HOME / "tmp"
 NOS_PATH = Path(__file__).parent
 
+DEFAULT_GRPC_PORT = 50051
+
 NOS_HOME.mkdir(parents=True, exist_ok=True)
 NOS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 NOS_MODELS_DIR.mkdir(parents=True, exist_ok=True)

--- a/nos/executors/docker.py
+++ b/nos/executors/docker.py
@@ -1,0 +1,168 @@
+"""Docker utilities to run containerized inference workloads
+(compile/infer) in detached mode.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import docker
+import docker.errors
+import docker.models.containers
+import docker.models.images
+import docker.models.volumes
+import docker.types
+from nos.logging import logger
+
+
+@dataclass
+class DockerDeviceRequest:
+    """Docker device request."""
+
+    device_ids: List[List[str]]
+    capabilities: List[List[str]]
+
+
+@dataclass
+class DeviceRequest:
+    """Device request."""
+
+    configs = {
+        "gpu": docker.types.DeviceRequest(
+            device_ids=["all"],
+            capabilities=[["gpu"]],
+        ),
+    }
+
+    @classmethod
+    def get(cls, device: str) -> "DockerDeviceRequest":
+        """Get device request."""
+        try:
+            return cls.configs[device]
+        except KeyError:
+            raise ValueError(f"Invalid DockerDeviceRequest: {device}")
+
+
+@dataclass
+class DockerExecutor:
+    """
+    Docker executor for running containerized inference workloads.
+    """
+
+    _instance: "DockerExecutor" = None
+    _client: docker.DockerClient = None
+
+    def __init__(self):
+        """Initialize DockerExecutor."""
+        self._client = docker.from_env()
+
+    @classmethod
+    def get(cls: "DockerExecutor") -> "DockerExecutor":
+        """Get DockerExecutor instance."""
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def start(
+        self,
+        image: str,
+        container_name: List[str],
+        ports: Optional[Dict[int, int]] = None,
+        command: Optional[List[str]] = None,
+        environment: Optional[Dict[str, str]] = None,
+        volumes: Optional[Dict[str, str]] = None,
+        detach: bool = True,
+        **kwargs: Any,
+    ) -> docker.models.containers.Container:
+        """Start container."""
+        container = self.get_container(container_name)
+
+        # If container is already running, return it
+        if container is not None:
+            if container.status == "running":
+                logger.info(f"Container already running: {container_name} id={container.id[:12]}")
+                logger.info(f"Get logs using `docker logs -f {container.id[:12]}`")
+                return container
+            else:
+                logger.info(f"Removing existing container: {container_name}")
+                container.remove(force=True)
+
+        # If container is not running, start it in detached mode
+        device_requests = []
+        if kwargs.pop("gpu", False):
+            device_requests = [DeviceRequest.get("gpu")]
+
+        # Try starting the container, if it fails, remove it and try again
+        logger.info(f"Starting container: {container_name}")
+        try:
+            container = self._client.containers.run(
+                image,
+                ports=ports,
+                command=command,
+                detach=detach,
+                name=container_name,
+                volumes=volumes,
+                device_requests=device_requests,
+                environment=environment,
+            )
+        except (docker.errors.APIError, docker.errors.DockerException) as exc:
+            if container is not None:
+                container.remove(force=True)
+            logger.error(f"Failed to start container: {exc}")
+            raise exc
+        logger.info(f"Started container: {container_name}")
+        logger.info(f"Get logs using `docker logs -f {container.id}`")
+        return container
+
+    def stop(self, container_name: str, timeout: int = 30) -> docker.models.containers.Container:
+        """Stop container."""
+        try:
+            container = self.get_container(container_name)
+            if container is None:
+                logger.info(f"Container not running: {container_name}, exiting early.")
+                return
+            logger.info(f"Stopping container: {container_name}")
+            container.stop(timeout=timeout)
+            logger.info(f"Stopped container: {container_name}")
+            container.remove(force=True)
+            logger.info(f"Removed container: {container_name}")
+        except (docker.errors.APIError, docker.errors.DockerException) as exc:
+            logger.error(f"Failed to stop container: {exc}")
+            raise exc
+        return container
+
+    def get_container(self, container_name: str) -> docker.models.containers.Container:
+        """Get container by name."""
+        try:
+            return self._client.containers.get(container_name)
+        except docker.errors.NotFound:
+            return None
+
+    def get_container_status(self, container_name: str) -> str:
+        """Get container status by name."""
+        container = self.get_container(container_name)
+        if container is None:
+            return None
+        return container.status
+
+    def get_logs(self, container_name: str, tail: int = 10, **kwargs: Any) -> str:
+        """Get container logs."""
+        try:
+            container = self.get_container(container_name)
+            if container is None:
+                return ""
+
+            return container.logs(tail=tail).decode("utf-8")
+        except (docker.errors.APIError, docker.errors.DockerException) as exc:
+            logger.error(f"Failed to get container logs: {exc}")
+            raise exc
+
+    def get_ports(self, container_name: str) -> Dict[int, int]:
+        """Get container ports."""
+        try:
+            container = self.get_container(container_name)
+            if container is None:
+                return {}
+            return {container_p: host_p.get("HostPort") for container_p, host_p in container.ports.items()}
+        except (docker.errors.APIError, docker.errors.DockerException) as exc:
+            logger.error(f"Failed to get container ports: {exc}")
+            raise exc

--- a/nos/executors/ray.py
+++ b/nos/executors/ray.py
@@ -1,3 +1,10 @@
+"""Ray executor for NOS.
+
+This module provides a Ray executor for NOS. The Ray executor is a singleton
+instance that can be used to start a Ray head, connect to an existing Ray
+cluster, and submit tasks to Ray. We use Ray as a backend for distributed
+computation and containerize them in docker to isolate the environment.
+"""
 import logging
 import os
 import subprocess
@@ -52,7 +59,7 @@ class RayExecutor:
         """Check if Ray is initialized."""
         return ray.is_initialized()
 
-    def init(self, timeout: int = 60) -> bool:
+    def init(self, max_attempts: int = 5, timeout: int = 60, retry_interval: int = 5) -> None:
         """Initialize Ray exector (as a daemon).
 
         Currently, this method will first attempt to connect to an existing
@@ -61,12 +68,14 @@ class RayExecutor:
         attempts, or if timeout of 60 seconds is reached).
 
         Args:
+            max_attempts: Number of retries to attempt to connect to an existing
             timeout: Time to wait for Ray to start. Defaults to 60 seconds.
+            retry_interval: Time to wait between retries. Defaults to 5 seconds.
         """
         level = getattr(logging, LOGGING_LEVEL)
 
         st = time.time()
-        attempt, max_attempts = 0, 5
+        attempt = 0
 
         # Attempt to connect to an existing ray cluster.
         # Allow upto 5 attempts, or if timeout of 60 seconds is reached.
@@ -91,8 +100,10 @@ class RayExecutor:
                 # start it in a background subprocess.
                 self.start()
                 attempt += 1
-                logger.info(f"Failed to connect to Ray head. Retrying {attempt}/{max_attempts}...")
-                time.sleep(5)
+                logger.info(
+                    f"Failed to connect to Ray head. Retrying {attempt}/{max_attempts} after {retry_interval}s..."
+                )
+                time.sleep(retry_interval)
         return False
 
     def start(self, wait: int = 5) -> Optional[int]:
@@ -105,8 +116,8 @@ class RayExecutor:
         with console.status("[bold green] Starting ray head (as daemon) ... [/bold green]"):
             # Check if Ray head is already running
             if self.pid:
-                console.print("[bold yellow] Ray head is already running. [/bold yellow]]")
-                return
+                console.print("[bold yellow] Ray head is already running. [/bold yellow]")
+                return self.pid
             # Start Ray head if not running
             RAY_TMP_DIR = NOS_TMP_DIR / "ray"
             RAY_TMP_DIR.mkdir(parents=True, exist_ok=True)
@@ -115,7 +126,7 @@ class RayExecutor:
             time.sleep(wait)
             if proc.poll() != 0:
                 raise RuntimeError("Failed to start Ray.")
-            return proc.pid
+            return self.pid
 
     def stop(self, wait: int = 5) -> Optional[int]:
         """Stop Ray head."""
@@ -131,7 +142,7 @@ class RayExecutor:
             time.sleep(wait)
             if proc.poll() != 0:
                 raise RuntimeError("Failed to stop Ray.")
-            return proc.pid
+            return self.pid
 
     @property
     def pid(self) -> Optional[int]:
@@ -140,3 +151,9 @@ class RayExecutor:
             if proc.name() == "raylet":
                 return proc.pid
         return None
+
+
+def init(*args, **kwargs) -> bool:
+    """Initialize Ray executor."""
+    exector = RayExecutor.get()
+    return exector.init(*args, **kwargs)

--- a/nos/experimental/grpc/__init__.py
+++ b/nos/experimental/grpc/__init__.py
@@ -1,6 +1,4 @@
 from .protoc import import_module  # noqa F401
-from .client import remote_model  # noqa F401
+from .client import remote_model, InferenceRuntime  # noqa F401
 from .server import InferenceService  # noqa F401
-
-
-DEFAULT_GRPC_PORT = 50051
+from nos.constants import DEFAULT_GRPC_PORT  # noqa F401

--- a/nos/experimental/grpc/client.py
+++ b/nos/experimental/grpc/client.py
@@ -4,12 +4,24 @@ Simple gRPC client for NOS service.
 Used for testing purposes and in conjunction with the NOS gRPC server (grpc_server.py).
 """
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
 
+from nos.constants import DEFAULT_GRPC_PORT  # noqa F401
+from nos.executors.docker import DockerExecutor
 from nos.experimental.grpc import import_module
+from nos.logging import LOGGING_LEVEL, logger
 
 
 nos_service_pb2 = import_module("nos_service_pb2")
 nos_service_pb2_grpc = import_module("nos_service_pb2_grpc")
+
+
+NOS_DOCKER_IMAGE_GPU = "autonomi-ai/nos:latest-gpu"
+NOS_DOCKER_IMAGE_CPU = "autonomi-ai/nos:latest-cpu"
+
+NOS_GRPC_SERVER_CONTAINER_NAME = "nos-grpc-server"
+NOS_GRPC_SERVER_CMD = "nos-grpc-server"
 
 
 @asynccontextmanager
@@ -18,7 +30,7 @@ async def remote_model(stub, model_name: str):
     # Create inference stub and init model
     request = nos_service_pb2.InitModelRequest(model_name=model_name, min_replicas=1, max_replicas=2)
     response: nos_service_pb2.InitModelResponse = await stub.InitModel(request)
-    print(response.result)
+    logger.info(f"Init Model response: {response}")
 
     # Yield so that the model inference can be done
     yield
@@ -26,4 +38,53 @@ async def remote_model(stub, model_name: str):
     # Delete model
     request = nos_service_pb2.DeleteModelRequest(model_name=model_name)
     response: nos_service_pb2.DeleteModelResponse = await stub.DeleteModel(request)
-    print(response.result)
+    logger.info(f"Delete Model response: {response}")
+
+
+@dataclass
+class InferenceRuntime:
+    """Inference docker runtime."""
+
+    _executor: DockerExecutor = None
+
+    def __init__(self):
+        """Initialize InferenceRuntime."""
+        self._executor = DockerExecutor.get()
+        logger.info(f"Initialized InferenceRuntime: {self._executor}")
+
+    def start(self, detach: bool = True, gpu: bool = False):
+        """Start the inference client.
+
+        Args:
+            gpu (bool, optional): Whether to start the client with GPU support. Defaults to False.
+        """
+        image = NOS_DOCKER_IMAGE_GPU if gpu else NOS_DOCKER_IMAGE_CPU
+        logger.info(f"Starting inference client with image: {image}")
+        nos_docker_path = Path.home() / ".nos_docker"
+        self._executor.start(
+            image=image,
+            container_name=NOS_GRPC_SERVER_CONTAINER_NAME,
+            command=[NOS_GRPC_SERVER_CMD],
+            ports={DEFAULT_GRPC_PORT: DEFAULT_GRPC_PORT},
+            environment={
+                "NOS_LOGGING_LEVEL": LOGGING_LEVEL,
+            },
+            volumes={
+                str(nos_docker_path): {"bind": "/app/.nos", "mode": "rw"},
+                "/tmp/docker": {"bind": "/tmp", "mode": "rw"},
+            },
+            shm_size="4g",
+            detach=detach,
+            remove=True,
+            gpu=gpu,
+        )
+        logger.info(f"Started inference client: {self._executor}")
+
+    def stop(self):
+        """Stop the inference client."""
+        self._executor.stop(NOS_GRPC_SERVER_CONTAINER_NAME)
+        logger.info(f"Stopped inference client: {self._executor}")
+
+    def get_logs(self):
+        """Get the inference client logs."""
+        return self._executor.get_logs(NOS_GRPC_SERVER_CONTAINER_NAME)

--- a/nos/experimental/grpc/protoc.py
+++ b/nos/experimental/grpc/protoc.py
@@ -67,7 +67,7 @@ class DynamicProtobufCompiler:
 
         # Load the module
         module_path = f"{Path(self.cache_dir) / module_name}.py"
-        logger.info(f"Loading module: {module_path}")
+        logger.debug(f"Loading module: {module_path}")
         spec = importlib.util.spec_from_file_location(module_name, module_path)
 
         module = importlib.util.module_from_spec(spec)

--- a/nos/experimental/grpc/server.py
+++ b/nos/experimental/grpc/server.py
@@ -9,6 +9,7 @@ from PIL import Image
 
 import grpc
 from nos import hub
+from nos.constants import DEFAULT_GRPC_PORT  # noqa F401
 from nos.exceptions import ModelNotFoundError
 from nos.experimental.grpc import import_module
 from nos.hub import MethodType

--- a/tests/executors/test_docker.py
+++ b/tests/executors/test_docker.py
@@ -1,0 +1,136 @@
+import time
+
+import pytest
+from loguru import logger
+
+from nos.executors.docker import DockerExecutor
+from nos.experimental.grpc.client import NOS_DOCKER_IMAGE_CPU, NOS_DOCKER_IMAGE_GPU, NOS_GRPC_SERVER_CMD
+from nos.test.utils import benchmark, requires_torch_cuda
+
+
+pytestmark = pytest.mark.skipif(not benchmark)
+
+
+def test_docker_executor_singleton():
+    """Test DockerExecutor singleton."""
+    executor = DockerExecutor.get()
+    executor_ = DockerExecutor.get()
+    assert executor is executor_
+
+
+def test_docker_executor_cpu():
+    """Test DockerExecutor for CPU."""
+    executor = DockerExecutor.get()
+    container_name = "nos-cpu-test"
+
+    # Force stop any existing containers
+    try:
+        executor.stop(container_name)
+    except Exception:
+        logger.info(f"Killing any existing container with name: {container_name}")
+
+    # Test CPU support
+    command = [NOS_GRPC_SERVER_CMD]
+    container = executor.start(
+        image=NOS_DOCKER_IMAGE_CPU,
+        container_name=container_name,
+        command=command,
+        detach=True,
+        gpu=False,
+    )
+    assert container is not None
+    assert container.id is not None
+
+    # Get container and status
+    container_ = executor.get_container(container_name)
+    status = executor.get_container_status(container_name)
+    assert container_.id == container.id
+    assert status is not None
+    assert status == "running"
+
+    # Try re-starting the container
+    # This should not fail, and should return the existing container
+    container_ = executor.start(
+        image=NOS_DOCKER_IMAGE_CPU,
+        container_name=container_name,
+        command=command,
+        detach=True,
+        gpu=True,
+    )
+    assert container_ is not None
+    assert container_.id is not None
+    assert container_.id == container.id
+
+    # Tear down
+    container = executor.stop(container_name)
+    assert container is not None
+
+    # Wait for container to stop (up to 20 seconds)
+    st = time.time()
+    while time.time() - st <= 20:
+        status = executor.get_container_status(container_name)
+        if status == "exited" or status is None:
+            break
+        time.sleep(1)
+    assert status is None or status == "exited"
+
+
+@requires_torch_cuda
+def test_docker_executor_gpu():
+    """Test DockerExecutor for GPU."""
+    executor = DockerExecutor.get()
+
+    # Test GPU support
+    container_name = "nos-gpu-test"
+    command = [NOS_GRPC_SERVER_CMD]
+    container = executor.start(
+        image=NOS_DOCKER_IMAGE_GPU,
+        container_name=container_name,
+        command=command,
+        detach=True,
+        gpu=True,
+    )
+    assert container is not None
+    assert container.id is not None
+
+    # Get container and status
+    status = executor.get_container_status(container_name)
+    assert status is not None
+    assert status == "running"
+
+    # Tear down
+    container = executor.stop(container_name)
+    assert container is not None
+    status = container.status
+
+    # Wait for container to stop (up to 20 seconds)
+    st = time.time()
+    while time.time() - st <= 20:
+        status = executor.get_container_status(container_name)
+        if status == "exited" or status is None:
+            break
+        time.sleep(1)
+    assert status is None or status == "exited"
+
+
+def test_docker_executor_logs():
+    """Test DockerExecutor logs."""
+    executor = DockerExecutor.get()
+
+    # Test CPU support
+    container_name = "nos-cpu-test"
+    command = [NOS_GRPC_SERVER_CMD]
+    container = executor.start(
+        image=NOS_DOCKER_IMAGE_GPU,
+        container_name=container_name,
+        command=command,
+        detach=True,
+        gpu=False,
+    )
+    assert container is not None
+    assert container.id is not None
+
+    # Get container logs
+    container = executor.get_container(container_name)
+    logs = executor.get_logs(container_name)
+    assert logs is not None

--- a/tests/executors/test_ray.py
+++ b/tests/executors/test_ray.py
@@ -9,6 +9,10 @@ def test_ray_executor():
     """Test ray executor singleton."""
     # Test singleton
     executor = RayExecutor.get()
+    executor_ = RayExecutor.get()
+    assert executor is executor_
+
+    # Check if Ray is initialized
     assert not executor.is_initialized()
     executor_ = RayExecutor.get()
     assert executor is executor_
@@ -23,7 +27,7 @@ def test_ray_executor():
     assert pid is not None
     assert isinstance(pid, int)
 
-    # # Stop Ray executor
+    # Stop Ray executor
     executor.stop()
     pid = executor.pid
     assert pid is None
@@ -40,10 +44,11 @@ def test_start_ray_executor():
     assert pid is not None
     assert isinstance(pid, int)
 
-    # re-start Ray executor
+    # Re-start Ray executor
     # this should avoid starting a new executor gracefully
-    pid = executor.start()
+    pid_ = executor.start()
     assert pid is not None
+    assert pid == pid_
 
 
 @benchmark
@@ -53,7 +58,7 @@ def test_stop_ray_executor():
     assert not executor.is_initialized()
 
     pid = executor.stop()
-    assert pid is not None
+    assert pid is None
 
 
 @pytest.mark.skip(reason="Not yet implemented.")


### PR DESCRIPTION
## Summary

This PR implements the main docker executor for running as a daemon
 - Support cpu/gpu docker device requests via kwargs `gpu=True`
 - Implements singleton `DockerExecutor` for background service
 - Simple `InferenceRuntime` client that starts the grpc server in the docker container
 - Tests: `test_docker.py`
 - minor fixes to `test_ray.py`
 - Updates makefile targets: `docker-build-cpu`, `docker-build-gpu`

 CLI: Added simple CLI for running `nos docker`
 - CPU: `nos docker start`
 - GPU: `nos docker start --gpu`
 
## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [x] GPU/HW tests
