### PR TITLE
Moved cuda base image to `cuda:11.8.0-base-ubuntu22.04`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: docker/Dockerfile
       args:
         - TARGET=gpu
-        - BASE_IMAGE=nvidia/cuda:11.8.0-runtime-ubuntu22.04
+        - BASE_IMAGE=nvidia/cuda:11.8.0-base-ubuntu22.04
     entrypoint: nos-grpc-server
     network_mode: host
     environment:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,6 @@ ADD requirements requirements
 RUN pip install --upgrade pip && \
     pip install -r requirements/requirements.txt
 ADD nos nos
-RUN pip install -e . --no-deps
 
 # NOS environment
 ENV NOS_HOME /app/.nos
@@ -53,8 +52,6 @@ ENV RAY_CONDA_HOME=${CONDA_PATH}
 ENV TORCH_HOME ${NOS_HOME}/cache/torch
 ENV TRANSFORMERS_CACHE ${NOS_HOME}/cache/transformers
 ENV HF_HOME ${NOS_HOME}/cache/transformers
-
-
 
 ENV PYTHONPATH=${PYTHONPATH}:/app/${PROJECT}
 RUN echo "export PYTHONPATH=${PYTHONPATH}:/app/${PROJECT}" >> ~/.bashrc

--- a/makefiles/Makefile.base.mk
+++ b/makefiles/Makefile.base.mk
@@ -29,10 +29,20 @@ docker-build-py3-cpu:
 docker-build-py3-gpu:
 	make .docker-build \
 	TARGET=gpu \
-	BASE_IMAGE=nvidia/cuda:11.8.0-runtime-ubuntu22.04
+	BASE_IMAGE=nvidia/cuda:11.8.0-base-ubuntu22.04
 
 docker-build-all: \
 	docker-build-py3-cpu docker-build-py3-gpu
 
 docker-compose-upd-py3-gpu: docker-build-py3-gpu
 	docker compose -f docker-compose.gpu.yml up
+
+docker-test-cpu: docker-build-py3-cpu
+	make .docker-run TARGET=cpu \
+	DOCKER_ARGS="-v $(shell pwd):/nos" \
+	DOCKER_CMD="make test-cpu"
+
+docker-test-gpu: docker-build-py3-gpu
+	make .docker-run TARGET=gpu \
+	DOCKER_ARGS="-v $(shell pwd):/nos --gpus all" \
+	DOCKER_CMD="make test"

--- a/nos/cli/system.py
+++ b/nos/cli/system.py
@@ -80,7 +80,7 @@ def _system_info() -> None:
     console.print(Panel(torch_gpu_info, title="Torch"))
 
     # Check if GPU is available
-    CUDA_RUNTIME_IMAGE = "nvidia/cuda:11.0.3-runtime-ubuntu18.04"
+    CUDA_RUNTIME_IMAGE = "nvidia/cuda:11.8.0-base-ubuntu22.04"
     nvidia_docker_gpu_info = ""
     try:
         # Get the output of nvidia-smi running in the container


### PR DESCRIPTION
Since Pytorch downloads the cuda libraries to link against,
we don't need to install the cuda libraries in the docker image. #57 

- updated docker-compose, and nos system images

<!-- Thank you for your contribution! Please review https://github.com/autonomi-ai/nos/blob/main/docs/CONTRIBUTING.md before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Summary

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
