### PR TITLE
MacOS support for `make develop-cpu`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.9
+  python: python3.8
 
 ci:
   autofix_prs: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Image Processing",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.8",
 ]
 dynamic = ["version", "dependencies"]
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@ accelerate>=0.18.0
 av>=10.0.0
 diffusers>=0.15.0
 docker>=6.0.0
-grpcio-tools>=1.51.0,<1.51.3
+grpcio-tools>=1.32.0,<=1.49.1  # from ray[serve]==2.4.0
 huggingface_hub
 loguru>=0.7.0
 opencv-python-headless==4.6.0.66


### PR DESCRIPTION
Addresses #62 

- fixes grpc version constraint to enable mac os dev installation

## Summary

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
