### PR TITLE
Add endpoint for faster-rcnn 

### DIFF
--- a/makefiles/Makefile.mmdet.mk
+++ b/makefiles/Makefile.mmdet.mk
@@ -28,5 +28,5 @@ docker-build-mmdet-gpu:
 
 docker-run-mmdet-grpc-server: docker-build-mmdet-gpu
 	make .docker-run-mmdet TARGET=gpu \
-	DOCKER_ARGS="--gpus all -v $(shell pwd):/nos -v ${HOME}/.nos_docker:/app/.nos -p 50051:50051" \
+	DOCKER_ARGS="--gpus all -v $(shell pwd):/nos -v ${HOME}/.nos_docker:/app/.nos -p 50051:50051 -p 8265:8265" \
 	DOCKER_CMD="nos-grpc-server"

--- a/nos/cli/serve_grpc.py
+++ b/nos/cli/serve_grpc.py
@@ -198,7 +198,7 @@ async def _predict_txt2img(
 async def _predict_img2bbox(
     ctx: typer.Context,
     model_name: str = typer.Option(
-        "open-mmlab/faster-rcnn",
+        "open-mmlab/efficientdet-d3",
         "-m",
         "--model-name",
         help="Name of the model to use (e.g. open-mmlab/efficientdet-d3).",

--- a/nos/models/clip.py
+++ b/nos/models/clip.py
@@ -32,8 +32,7 @@ class CLIP:
         ),
     }
 
-    # def __init__(self, model_name: str = "openai/clip-vit-base-patch32"):
-    def __init__(self, model_name: str):
+    def __init__(self, model_name: str = "openai/clip-vit-base-patch32"):
         from transformers import CLIPModel, CLIPProcessor, CLIPTokenizer
 
         self.cfg = CLIP.configs.get(model_name)

--- a/nos/models/openmmlab/mmdetection/configs/_base_/models/faster-rcnn_r50_fpn.py
+++ b/nos/models/openmmlab/mmdetection/configs/_base_/models/faster-rcnn_r50_fpn.py
@@ -1,0 +1,114 @@
+# model settings
+model = dict(
+    type='FasterRCNN',
+    data_preprocessor=dict(
+        type='DetDataPreprocessor',
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        bgr_to_rgb=True,
+        pad_size_divisor=32),
+    backbone=dict(
+        type='ResNet',
+        depth=50,
+        num_stages=4,
+        out_indices=(0, 1, 2, 3),
+        frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
+        norm_eval=True,
+        style='pytorch',
+        init_cfg=dict(type='Pretrained', checkpoint='torchvision://resnet50')),
+    neck=dict(
+        type='FPN',
+        in_channels=[256, 512, 1024, 2048],
+        out_channels=256,
+        num_outs=5),
+    rpn_head=dict(
+        type='RPNHead',
+        in_channels=256,
+        feat_channels=256,
+        anchor_generator=dict(
+            type='AnchorGenerator',
+            scales=[8],
+            ratios=[0.5, 1.0, 2.0],
+            strides=[4, 8, 16, 32, 64]),
+        bbox_coder=dict(
+            type='DeltaXYWHBBoxCoder',
+            target_means=[.0, .0, .0, .0],
+            target_stds=[1.0, 1.0, 1.0, 1.0]),
+        loss_cls=dict(
+            type='CrossEntropyLoss', use_sigmoid=True, loss_weight=1.0),
+        loss_bbox=dict(type='L1Loss', loss_weight=1.0)),
+    roi_head=dict(
+        type='StandardRoIHead',
+        bbox_roi_extractor=dict(
+            type='SingleRoIExtractor',
+            roi_layer=dict(type='RoIAlign', output_size=7, sampling_ratio=0),
+            out_channels=256,
+            featmap_strides=[4, 8, 16, 32]),
+        bbox_head=dict(
+            type='Shared2FCBBoxHead',
+            in_channels=256,
+            fc_out_channels=1024,
+            roi_feat_size=7,
+            num_classes=80,
+            bbox_coder=dict(
+                type='DeltaXYWHBBoxCoder',
+                target_means=[0., 0., 0., 0.],
+                target_stds=[0.1, 0.1, 0.2, 0.2]),
+            reg_class_agnostic=False,
+            loss_cls=dict(
+                type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0),
+            loss_bbox=dict(type='L1Loss', loss_weight=1.0))),
+    # model training and testing settings
+    train_cfg=dict(
+        rpn=dict(
+            assigner=dict(
+                type='MaxIoUAssigner',
+                pos_iou_thr=0.7,
+                neg_iou_thr=0.3,
+                min_pos_iou=0.3,
+                match_low_quality=True,
+                ignore_iof_thr=-1),
+            sampler=dict(
+                type='RandomSampler',
+                num=256,
+                pos_fraction=0.5,
+                neg_pos_ub=-1,
+                add_gt_as_proposals=False),
+            allowed_border=-1,
+            pos_weight=-1,
+            debug=False),
+        rpn_proposal=dict(
+            nms_pre=2000,
+            max_per_img=1000,
+            nms=dict(type='nms', iou_threshold=0.7),
+            min_bbox_size=0),
+        rcnn=dict(
+            assigner=dict(
+                type='MaxIoUAssigner',
+                pos_iou_thr=0.5,
+                neg_iou_thr=0.5,
+                min_pos_iou=0.5,
+                match_low_quality=False,
+                ignore_iof_thr=-1),
+            sampler=dict(
+                type='RandomSampler',
+                num=512,
+                pos_fraction=0.25,
+                neg_pos_ub=-1,
+                add_gt_as_proposals=True),
+            pos_weight=-1,
+            debug=False)),
+    test_cfg=dict(
+        rpn=dict(
+            nms_pre=1000,
+            max_per_img=1000,
+            nms=dict(type='nms', iou_threshold=0.7),
+            min_bbox_size=0),
+        rcnn=dict(
+            score_thr=0.05,
+            nms=dict(type='nms', iou_threshold=0.5),
+            max_per_img=100)
+        # soft-nms is also supported for rcnn testing
+        # e.g., nms=dict(type='soft_nms', iou_threshold=0.5, min_score=0.05)
+    ))

--- a/nos/models/openmmlab/mmdetection/configs/faster-rcnn/faster-rcnn_r50_fpn_1x_coco.py
+++ b/nos/models/openmmlab/mmdetection/configs/faster-rcnn/faster-rcnn_r50_fpn_1x_coco.py
@@ -1,0 +1,5 @@
+_base_ = [
+    '../_base_/models/faster-rcnn_r50_fpn.py',
+    '../_base_/datasets/coco_detection.py',
+    '../_base_/schedules/schedule_1x.py', '../_base_/default_runtime.py'
+]


### PR DESCRIPTION
Identical interface to efficient-det. Matches tutorial flow from https://gitlab.com/pixeltable/python-sdk/-/blob/master/tutorials/Pixeltable%20Overview.ipynb

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
