### PR TITLE
Torch FasterRCNN endpoint

### DIFF
--- a/nos/models/__init__.py
+++ b/nos/models/__init__.py
@@ -3,6 +3,6 @@ import torch
 from nos import hub
 
 from .clip import CLIP  # noqa: F401
+from .faster_rcnn import FasterRCNN
 from .openmmlab.mmdetection.mmdetection import MMDetection  # noqa: F401
 from .stable_diffusion import StableDiffusion2  # noqa: F401
-from .faster_rcnn import FasterRCNN

--- a/nos/models/faster_rcnn.py
+++ b/nos/models/faster_rcnn.py
@@ -44,13 +44,13 @@ class FasterRCNN:
                 images = np.asarray(images)
             elif isinstance(images, list):
                 raise ValueError("Batching not yet supported")
-            
+
             tensor = torch.as_tensor(images.astype("float32")).permute(2, 0, 1)
             predictions = self.model([tensor])
             return {
-                "scores": predictions[0]['boxes'].cpu().numpy(),
-                "labels": predictions[0]['labels'].cpu().numpy(),
-                "bboxes": predictions[0]['boxes'].cpu().numpy(),
+                "scores": predictions[0]["boxes"].cpu().numpy(),
+                "labels": predictions[0]["labels"].cpu().numpy(),
+                "bboxes": predictions[0]["boxes"].cpu().numpy(),
             }
 
 


### PR DESCRIPTION
Introduce a torch faster-rcnn endpoint for img2bbox (not MMDetection)

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
