### PR TITLE
Build cpu docker container as part of CI actions to check conda env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   conda-test-cpu:
-    name: Test env (${{ matrix.python-version }}, ${{ matrix.os }})
+    name: Test conda env (${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
@@ -51,7 +51,7 @@ jobs:
       - name: Test
         run: make test-cpu
   docker-test-cpu:
-    name: Test env (${{ matrix.python-version }}, ${{ matrix.os }})
+    name: Test conda env in docker (${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:


### PR DESCRIPTION
We should be regression testing our conda environments to ensure that everything remains reproducible. This adds `docker-build-cpu` to github CI actions which will enforce that the `base-cpu` conda env is always buildable inside of docker as well. We should do the same for the GPU environment as well, but might want to wait until we have a GPU capable dev server to run on in case we want to add the tests to CI.

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
