### PR TITLE
Exclude nos/experimental from wheel build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ dependency_links = [
 
 [tool.setuptools.packages.find]
 include = ["nos*","scripts*"]
+exclude = [
+    "nos*experimental*",
+]
 
 [tool.setuptools.package-data]
 "*" = ["*.json", "py.typed", "setup.bash", "setup.zsh"]


### PR DESCRIPTION
Wheel file comes out to 40K. Should be good enough for #79 

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
