### PR TITLE
Fix for ray-gcs server errors on multiple restarts

### DIFF
--- a/nos/server/service.py
+++ b/nos/server/service.py
@@ -71,7 +71,8 @@ class InferenceService(nos_service_pb2_grpc.InferenceServiceServicer):
         try:
             self.executor.init()
         except Exception as e:
-            logger.error(f"Failed to initialize executor: {e}")
+            logger.info(f"Failed to initialize executor: {e}")
+            raise RuntimeError(f"Failed to initialize executor: {e}")
 
     def init_model(self, model_name: str):
         """Initialize the model."""
@@ -209,7 +210,7 @@ def serve(address: str = f"[::]:{DEFAULT_GRPC_PORT}", max_workers: int = 1) -> N
     with console.status(f"[bold green] Starting server on {address}[/bold green]") as status:
         server.start()
         console.print(
-            f"[bold green] ✓ Deployment complete [/bold green]",  # noqa
+            f"[bold green] ✓ InferenceService :: Deployment complete [/bold green]",  # noqa
         )
         status.stop()
         server.wait_for_termination()

--- a/nos/test/conftest.py
+++ b/nos/test/conftest.py
@@ -7,19 +7,12 @@ from nos.client import DEFAULT_GRPC_PORT, InferenceClient
 from nos.executors.ray import RayExecutor
 from nos.protoc import import_module
 from nos.server import InferenceService
-from nos.server.docker import DockerRuntime
 
 
 GRPC_TEST_PORT = DEFAULT_GRPC_PORT + 1
 
 nos_service_pb2 = import_module("nos_service_pb2")
 nos_service_pb2_grpc = import_module("nos_service_pb2_grpc")
-
-
-@pytest.fixture(scope="session")
-def docker_runtime():
-    runtime = DockerRuntime.get()
-    yield runtime
 
 
 @pytest.fixture(scope="session")

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -1,0 +1,99 @@
+import time
+
+import pytest
+from loguru import logger
+
+from nos.server.docker import DockerRuntime
+from nos.server.runtime import NOS_DOCKER_IMAGE_CPU, NOS_DOCKER_IMAGE_GPU, NOS_GRPC_SERVER_CMD
+
+
+CPU_CONTAINER_NAME = "nos-cpu-test"
+GPU_CONTAINER_NAME = "nos-gpu-test"
+
+
+@pytest.fixture(scope="session")
+def grpc_server_runtime_cpu_container():
+    """Test DockerRuntime CPU."""
+    docker_runtime = DockerRuntime.get()
+
+    # Force stop any existing containers
+    try:
+        docker_runtime.stop(CPU_CONTAINER_NAME)
+    except Exception:
+        logger.info(f"Killing any existing container with name: {CPU_CONTAINER_NAME}")
+
+    # Start grpc server runtime (CPU)
+    container = docker_runtime.start(
+        image=NOS_DOCKER_IMAGE_CPU,
+        container_name=CPU_CONTAINER_NAME,
+        command=[NOS_GRPC_SERVER_CMD],
+        detach=True,
+        gpu=False,
+    )
+    assert container is not None
+    assert container.id is not None
+
+    # Get container and status
+    container_ = docker_runtime.get_container(CPU_CONTAINER_NAME)
+    status = docker_runtime.get_container_status(CPU_CONTAINER_NAME)
+    assert container_.id == container.id
+    assert status is not None
+    assert status == "running"
+
+    yield container
+
+    # Tear down (raise errors if this fails)
+    docker_runtime.stop(CPU_CONTAINER_NAME)
+
+    # Wait for container to stop (up to 20 seconds)
+    st = time.time()
+    while time.time() - st <= 20:
+        status = docker_runtime.get_container_status(CPU_CONTAINER_NAME)
+        if status == "exited" or status is None:
+            break
+        time.sleep(1)
+    assert status is None or status == "exited"
+
+
+@pytest.fixture(scope="session")
+def grpc_server_runtime_gpu_container():
+    """Test DockerRuntime GPU."""
+    docker_runtime = DockerRuntime.get()
+
+    # Force stop any existing containers
+    try:
+        docker_runtime.stop(GPU_CONTAINER_NAME)
+    except Exception:
+        logger.info(f"Killing any existing container with name: {GPU_CONTAINER_NAME}")
+
+    # Start grpc server runtime (GPU)
+    container = docker_runtime.start(
+        image=NOS_DOCKER_IMAGE_GPU,
+        container_name=GPU_CONTAINER_NAME,
+        command=[NOS_GRPC_SERVER_CMD],
+        detach=True,
+        gpu=True,
+    )
+    assert container is not None
+    assert container.id is not None
+
+    # Get container and status
+    container_ = docker_runtime.get_container(GPU_CONTAINER_NAME)
+    status = docker_runtime.get_container_status(GPU_CONTAINER_NAME)
+    assert container_.id == container.id
+    assert status is not None
+    assert status == "running"
+
+    yield container
+
+    # Tear down (raise errors if this fails)
+    docker_runtime.stop(GPU_CONTAINER_NAME)
+
+    # Wait for container to stop (up to 20 seconds)
+    st = time.time()
+    while time.time() - st <= 20:
+        status = docker_runtime.get_container_status(GPU_CONTAINER_NAME)
+        if status == "exited" or status is None:
+            break
+        time.sleep(1)
+    assert status is None or status == "exited"

--- a/tests/server/test_docker_runtime.py
+++ b/tests/server/test_docker_runtime.py
@@ -1,131 +1,58 @@
-import time
-
 import pytest
-from loguru import logger
 
 from nos.server.docker import DockerRuntime
 from nos.server.runtime import NOS_DOCKER_IMAGE_CPU, NOS_DOCKER_IMAGE_GPU, NOS_GRPC_SERVER_CMD
-from nos.test.conftest import docker_runtime  # noqa: F401
 from nos.test.utils import skip_if_no_torch_cuda
 
 
 pytestmark = pytest.mark.e2e
 
 
-def test_docker_runtime_singleton(docker_runtime: DockerRuntime):  # noqa: F811
+def test_docker_runtime_singleton():
     """Test DockerRuntime singleton."""
+    docker_runtime = DockerRuntime.get()
     docker_runtime_ = DockerRuntime.get()
     assert docker_runtime is docker_runtime_
 
 
-def test_docker_runtime_cpu(docker_runtime: DockerRuntime):  # noqa: F811
+def test_docker_runtime_cpu(grpc_server_runtime_cpu_container):
     """Test DockerRuntime for CPU."""
-    container_name = "nos-cpu-test"
-
-    # Force stop any existing containers
-    try:
-        docker_runtime.stop(container_name)
-    except Exception:
-        logger.info(f"Killing any existing container with name: {container_name}")
-
-    # Test CPU support
-    command = [NOS_GRPC_SERVER_CMD]
-    container = docker_runtime.start(
-        image=NOS_DOCKER_IMAGE_CPU,
-        container_name=container_name,
-        command=command,
-        detach=True,
-        gpu=False,
-    )
-    assert container is not None
-    assert container.id is not None
-
-    # Get container and status
-    container_ = docker_runtime.get_container(container_name)
-    status = docker_runtime.get_container_status(container_name)
-    assert container_.id == container.id
-    assert status is not None
-    assert status == "running"
-
     # Try re-starting the container
     # This should not fail, and should return the existing container
+    docker_runtime = DockerRuntime.get()
     container_ = docker_runtime.start(
         image=NOS_DOCKER_IMAGE_CPU,
-        container_name=container_name,
-        command=command,
+        container_name=grpc_server_runtime_cpu_container.name,
+        command=[NOS_GRPC_SERVER_CMD],
         detach=True,
-        gpu=True,
+        gpu=False,
     )
     assert container_ is not None
     assert container_.id is not None
-    assert container_.id == container.id
-
-    # Tear down
-    container = docker_runtime.stop(container_name)
-    assert container is not None
-
-    # Wait for container to stop (up to 20 seconds)
-    st = time.time()
-    while time.time() - st <= 20:
-        status = docker_runtime.get_container_status(container_name)
-        if status == "exited" or status is None:
-            break
-        time.sleep(1)
-    assert status is None or status == "exited"
+    assert container_.id == grpc_server_runtime_cpu_container.id
 
 
 @skip_if_no_torch_cuda
-def test_docker_runtime_gpu(docker_runtime: DockerRuntime):  # noqa: F811
+def test_docker_runtime_gpu(grpc_server_runtime_gpu_container):
     """Test DockerRuntime for GPU."""
-    # Test GPU support
-    container_name = "nos-gpu-test"
-    command = [NOS_GRPC_SERVER_CMD]
-    container = docker_runtime.start(
+    # Try re-starting the container
+    # This should not fail, and should return the existing container
+    docker_runtime = DockerRuntime.get()
+    container_ = docker_runtime.start(
         image=NOS_DOCKER_IMAGE_GPU,
-        container_name=container_name,
-        command=command,
-        detach=True,
-        gpu=True,
-    )
-    assert container is not None
-    assert container.id is not None
-
-    # Get container and status
-    status = docker_runtime.get_container_status(container_name)
-    assert status is not None
-    assert status == "running"
-
-    # Tear down
-    container = docker_runtime.stop(container_name)
-    assert container is not None
-    status = container.status
-
-    # Wait for container to stop (up to 20 seconds)
-    st = time.time()
-    while time.time() - st <= 20:
-        status = docker_runtime.get_container_status(container_name)
-        if status == "exited" or status is None:
-            break
-        time.sleep(1)
-    assert status is None or status == "exited"
-
-
-def test_docker_runtime_logs(docker_runtime: DockerRuntime):  # noqa: F811
-    """Test Dockerdocker_runtime logs."""
-    # Test CPU support
-    container_name = "nos-cpu-test"
-    command = [NOS_GRPC_SERVER_CMD]
-    container = docker_runtime.start(
-        image=NOS_DOCKER_IMAGE_GPU,
-        container_name=container_name,
-        command=command,
+        container_name=grpc_server_runtime_gpu_container.name,
+        command=[NOS_GRPC_SERVER_CMD],
         detach=True,
         gpu=False,
     )
-    assert container is not None
-    assert container.id is not None
+    assert container_ is not None
+    assert container_.id is not None
+    assert container_.id == grpc_server_runtime_gpu_container.id
 
-    # Get container logs
-    container = docker_runtime.get_container(container_name)
-    logs = docker_runtime.get_logs(container_name)
+
+def test_docker_runtime_logs(grpc_server_runtime_cpu_container):  # noqa: F811
+    """Test Dockerdocker_runtime logs."""
+    docker_runtime = DockerRuntime.get()
+    docker_runtime.get_container(grpc_server_runtime_cpu_container.name)
+    logs = docker_runtime.get_logs(grpc_server_runtime_cpu_container.name)
     assert logs is not None

--- a/tests/server/test_inference_service_runtime.py
+++ b/tests/server/test_inference_service_runtime.py
@@ -1,13 +1,11 @@
 import pytest
 
 from nos.server import InferenceServiceRuntime
-from nos.server.docker import DockerRuntime
-from nos.test.conftest import docker_runtime  # noqa: F401
 
 
 pytestmark = pytest.mark.e2e
 
 
-def test_inference_service_runtime(docker_runtime: DockerRuntime):  # noqa: F811
+def test_inference_service_runtime(grpc_server_runtime_cpu_container):  # noqa: F811
     runtime = InferenceServiceRuntime()
     assert runtime is not None


### PR DESCRIPTION
If we cache the tmp directory, it turns out that ray looks for the last
time we initialize the server with the same port and tries to re-connect.
It does this by looking for the cached `/tmp/ray/ray_current_cluster`
file, however, the cluster is no longer running and so it fails.

This new implementation fixes this by forcing ray to start a new
cluster, via `ray.init(address="local")` and then connecting to the
server via `ray.init(address="auto")`. The first call to
`ray.init(address="auto")` raises a `ConnectionError` and proceeds to
force-start a new ray cluster instance, followed by a second call to
`ray.init(address="auto")` which successfully connects to the server.

<!-- Thank you for your contribution! Please review https://github.com/autonomi-ai/nos/blob/main/docs/CONTRIBUTING.md before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Summary

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
