### PR TITLE
Improved dockerfile builds with caching and fix for proto includes in…

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,7 +5,6 @@ x-nos-common:
   volumes:
     - ~/.nosd:/app/.nos
     - /tmp/docker:/tmp
-    - /dev/shm:/dev/shm
   environment:
     - NOS_LOGGING=DEBUG
   shm_size: 4G

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,37 +23,43 @@ RUN apt-get -y update \
 ENV CONDA_PATH=/opt/conda/envs/${PYENV}
 ENV CONDA_PREFIX=${CONDA_PATH}
 ENV CONDA_EXE=${CONDA_PATH}/bin/conda
-ENV PATH=${CONDA_PATH}/bin:$PATH
+ENV PATH=${CONDA_PATH}/bin:/opt/conda/bin:$PATH
+ENV CONDA_DEFAULT_ENV ${PYENV}
 
 # Install mambaforge
-COPY ./conda/envs/base-${TARGET}/env.yml /tmp/conda/envs/base-${TARGET}/env.yml
 RUN curl -sLo ~/mambaforge.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh" \
   && chmod +x ~/mambaforge.sh \
   && ~/mambaforge.sh -b -p /opt/conda \
   && /opt/conda/bin/mamba init bash \
   && /opt/conda/bin/mamba create -n ${PYENV} python=${PYTHON_VERSION} -y \
-  && rm ~/mambaforge.sh \
-  && rm /tmp/conda/envs/base-${TARGET}/env.yml  \
-  && /opt/conda/bin/mamba clean -ya \
-  && rm -rf /opt/conda/pkgs/*
+  && rm ~/mambaforge.sh
 
 # NOS dependencies and install
-WORKDIR /app/$PROJECT
+WORKDIR /tmp/$PROJECT
 ADD pyproject.toml .
 ADD requirements requirements
+
 # Install torch (cpu/gpu) based on target
-RUN if [ "${TARGET}" = "cpu" ]; then \
-  /opt/conda/bin/mamba install -y pytorch torchvision cpuonly -c pytorch; \
+RUN --mount=type=cache,target=/opt/conda/pkgs/ \
+  if [ "${TARGET}" = "cpu" ]; then \
+    mamba install -yv pytorch torchvision cpuonly -c pytorch; \
   else \
-  /opt/conda/bin/mamba install -y pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch -c nvidia; \
+    mamba install -yv pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch -c nvidia; \
   fi
-# Iinstall client/server dependencies
-RUN pip install \
+
+# Install client/server dependencies
+RUN --mount=type=cache,target=~/.cache/pip \
+  pip install \
   -r requirements/requirements.txt \
-  -r requirements/requirements.server.txt \
-  && rm -rf ~/.cache/pip
+  -r requirements/requirements.server.txt
 ADD nos nos
-RUN pip install -e . --no-deps
+RUN pip install . --no-deps
+
+# Cleanup
+RUN /opt/conda/bin/mamba clean -ya \
+  && rm -rf /opt/conda/pkgs/* \
+  && rm -rf ~/.cache/pip \
+  && rm -rf /tmp/$PROJECT
 
 # NOS environment
 WORKDIR /app/$PROJECT
@@ -71,9 +77,10 @@ ENV RAY_USAGE_STATS_ENABLED 0
 ENV RAY_DATA_DISABLE_PROGRESS_BARS 1
 ENV RAY_CONDA_HOME=${CONDA_PATH}
 
-ENV PYTHONPATH=${PYTHONPATH}:/app/${PROJECT}
-RUN echo "export PYTHONPATH=${PYTHONPATH}:/app/${PROJECT}" >> ~/.bashrc
+RUN echo "export CONDA_PATH=/opt/conda/envs/${PYENV}" >> ~/.bashrc
 RUN echo "export PATH=/opt/conda/envs/${PYENV}/bin:$PATH" >> ~/.bashrc
+RUN echo "export CONDA_DEFAULT_ENV=${PYENV}" >> ~/.bashrc
+RUN echo "mamba activate ${PYENV}" > ~/.bashrc
 
 CMD ["nos-grpc-server"]
 
@@ -81,7 +88,10 @@ CMD ["nos-grpc-server"]
 FROM base as test
 RUN apt-get update \
   && apt-get install make
-ADD tests tests
+ADD pyproject.toml .
+ADD requirements requirements
 ADD makefiles makefiles
 ADD Makefile .
+ADD nos nos
+ADD tests tests
 RUN pip install -e '.[test]'

--- a/nos/protoc.py
+++ b/nos/protoc.py
@@ -29,6 +29,7 @@ class DynamicProtobufCompiler:
         sys.path.append(str(self.cache_dir))
 
         # Compile all proto files from all paths
+        logger.debug(f"Compiling protos from: {PROTO_PATHS}")
         for path in itertools.chain.from_iterable(Path(path).glob("*.proto") for path in PROTO_PATHS):
             logger.debug(f"Compiling {path}")
             self.compile(str(path))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ exclude = [
 ]
 
 [tool.setuptools.package-data]
-"*" = ["*.json", "py.typed", "setup.bash", "setup.zsh"]
+"*" = ["*.json", "*.proto"]
 
 [tool.black]
 line-length = 119


### PR DESCRIPTION
… `pyproject.toml`

 - improved docker build caching for faster mamba and pip installs
 - fix for `*.proto` includes in `pyproject.toml`
 - we now `pip install .` to install `nos` into the conda env python site-packages

<!-- Thank you for your contribution! Please review https://github.com/autonomi-ai/nos/blob/main/docs/CONTRIBUTING.md before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Summary

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
