### PR TITLE
Give CPU tests a non-parametrized name to see if it shows up in gatin…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ env:
 
 jobs:
   conda-test-cpu:
-    name: Test conda env (${{ matrix.python-version }}, ${{ matrix.os }})
+    # name: Test conda env (${{ matrix.python-version }}, ${{ matrix.os }})
+  name: Test conda env
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:


### PR DESCRIPTION
https://stackoverflow.com/questions/68554735/github-action-status-check-missing-from-the-list-of-checks-in-protected-branch-s

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
