### PR TITLE
Refactor `InferenceServiceRuntime` and `DockerRuntime`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,9 @@ help:
 	@echo "  lint                Format source code automatically"
 	@echo "  test                Basic GPU/CPU testing with a single GPU"
 	@echo "  test-cpu            Basic CPU testing"
+	@echo "  test-client         Basic client-side testing"
+	@echo "  test-server         Server-side testing (all GPUs)"
 	@echo "  test-benchmark      Testing with benchmarks (all GPUs)"
-	@echo "  test-e2e            End-to-end testing (all GPUs)"
 	@echo "  dist                Builds source and wheel package"
 	@echo ""
 
@@ -101,11 +102,11 @@ test-client: docker-build-cpu docker-build-gpu ## Basic client-side testing
 test-benchmark: ## Testing with benchmarks (all GPUs)
 	pytest -sv tests -m "benchmark"
 
-test-e2e: ## End-to-end testing (all GPUs)
-	pytest -sv tests -m "e2e"
+test-server: ## Server-side testing (all GPUs)
+	pytest -sv tests -m "server"
 
-test-all:  ## ALl tests including CPU, GPU, client, and e2e
-	make test-cpu test-gpu test-client test-e2e
+test-all:  ## ALl tests including CPU, GPU, client, and server
+	make test-cpu test-gpu test-client test-server
 
 dist: clean ## builds source and wheel package
 	python -m build --sdist --wheel

--- a/nos/cli/system.py
+++ b/nos/cli/system.py
@@ -87,7 +87,7 @@ def _system_info() -> None:
     try:
         # Get the output of nvidia-smi running in the container
         container = executor.start(
-            image=CUDA_RUNTIME_IMAGE, container_name="nos-server-gpu-test", command="nvidia-smi", detach=True, gpu=True
+            image=CUDA_RUNTIME_IMAGE, name="nos-server-gpu-test", command="nvidia-smi", detach=True, gpu=True
         )
         for i, log in enumerate(container.logs(stream=True)):
             nvidia_docker_gpu_info += "\n" if i > 0 else ""

--- a/nos/server/docker.py
+++ b/nos/server/docker.py
@@ -3,7 +3,7 @@
 """
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Iterable, List, Optional, Union
 
 import docker
 import docker.errors
@@ -65,113 +65,110 @@ class DockerRuntime:
     def start(
         self,
         image: str,
-        container_name: str,
-        ports: Optional[Dict[int, int]] = None,
-        command: Optional[List[str]] = None,
-        environment: Optional[Dict[str, str]] = None,
-        volumes: Optional[Dict[str, str]] = None,
-        detach: bool = True,
-        shm_size: str = "4g",
+        command: Optional[Union[str, List[str]]] = None,
+        name: str = None,
         **kwargs: Any,
     ) -> docker.models.containers.Container:
-        """Start docker container."""
-        container = self.get_container(container_name)
+        """Start docker container.
 
-        # If container is already running, return it
-        if container is not None:
+        Args:
+            **kwargs: See https://docker-py.readthedocs.io/en/stable/containers.html#docker.models.containers.ContainerCollection.run
+            ports (Optional[Dict[int, int]], optional): Port mapping. Defaults to None.
+            environment (Optional[Dict[str, str]], optional): Environment variables. Defaults to None.
+            volumes (Optional[Dict[str, str]], optional): Volume mapping. Defaults to None.
+            shm_size (Optional[int], optional): Shared memory size. Defaults to None.
+            detach (bool, optional): Whether to run the container in detached mode. Defaults to True.
+            remove (bool, optional): Whether to remove the container when it exits. Defaults to True.
+            gpu (bool, optional): Whether to start the container with GPU support. Defaults to False.
+
+        Note (Non-standard arguments):
+            gpu (bool): Whether to start the container with GPU support.
+
+        """
+        # Check if container is already running, raise error if it is
+        if name and self.get_container(name) is not None:
+            container = self.get_container(name)
             if container.status == "running":
-                logger.info(f"Container already running: {container_name} id={container.id[:12]}")
-                logger.info(f"Get logs using `docker logs -f {container.id[:12]}`")
-                return container
+                raise RuntimeError(f"Container with same name already running (name={name}).")
             else:
-                logger.info(f"Removing existing container: {container_name}")
-                container.remove(force=True)
+                logger.warning(f"Container with same name already exists, removing it (name={name}).")
+                self.stop(name)
 
-        # If container is not running, start it in detached mode
+        # Validate kwargs before passing to `containers.run(...)`
+        if "device_requests" in kwargs:
+            raise ValueError("Use `gpu=True` instead of `device_requests`.")
+
+        # Handle device requests (gpu=True)
         device_requests = []
         if kwargs.pop("gpu", False):
             device_requests = [DeviceRequest.get("gpu")]
 
         # Try starting the container, if it fails, remove it and try again
-        logger.info(f"Starting container: {container_name}")
+        logger.debug(f"Starting container: {name}")
         logger.debug(f"\timage: {image}")
-        logger.debug(f"\tports: {ports}")
         logger.debug(f"\tcommand: {command}")
-        logger.debug(f"\tenvironment: {environment}")
-        logger.debug(f"\tvolumes: {volumes}")
-        logger.debug(f"\tshm_size: {shm_size}")
+        logger.debug(f"\tname: {name}")
         logger.debug(f"\tdevice: {device_requests}")
+        for k, v in kwargs.items():
+            logger.debug(f"\t{k}: {v}")
+
+        # Start container (pass through kwargs)
         try:
             container = self._client.containers.run(
                 image,
-                ports=ports,
                 command=command,
-                detach=detach,
-                name=container_name,
-                volumes=volumes,
+                name=name,
                 device_requests=device_requests,
-                environment=environment,
-                shm_size=shm_size,
                 **kwargs,
             )
+            logger.info(f"Started container: {name}")
+            logger.info(f"Get logs using `docker logs -f {container.id[:12]}`")
         except (docker.errors.APIError, docker.errors.DockerException) as exc:
-            if container is not None:
-                container.remove(force=True)
-            logger.error(f"Failed to start container: {exc}")
+            logger.error(f"Failed to start container, cleaning up container: {exc}")
+            self.stop(name)
             raise exc
-        logger.info(f"Started container: {container_name}")
-        logger.info(f"Get logs using `docker logs -f {container.id[:12]}`")
         return container
 
-    def stop(self, container_name: str, timeout: int = 30) -> docker.models.containers.Container:
+    def stop(self, name: str, timeout: int = 30) -> docker.models.containers.Container:
         """Stop docker container."""
         try:
-            container = self.get_container(container_name)
+            container = self.get_container(name)
             if container is None:
-                logger.info(f"Container not running: {container_name}, exiting early.")
+                logger.debug(f"Container not running: {name}, exiting early.")
                 return
-            logger.info(f"Stopping container: {container_name}")
-            container.stop(timeout=timeout)
-            logger.info(f"Stopped container: {container_name}")
+            logger.debug(f"Removing container: {name}")
             container.remove(force=True)
-            logger.info(f"Removed container: {container_name}")
+            logger.info(f"Removed container: {name}")
         except (docker.errors.APIError, docker.errors.DockerException) as exc:
             logger.error(f"Failed to stop container: {exc}")
         return container
 
-    def get_container(self, container_name: str) -> docker.models.containers.Container:
+    def get_container(self, name: str) -> docker.models.containers.Container:
         """Get container by name."""
         try:
-            return self._client.containers.get(container_name)
+            return self._client.containers.get(name)
         except docker.errors.NotFound:
             return None
 
-    def get_container_status(self, container_name: str) -> str:
-        """Get container status by name."""
-        container = self.get_container(container_name)
-        if container is None:
-            return None
-        return container.status
+    def get_container_id(self, name: str) -> Optional[str]:
+        """Get the runtime container ID."""
+        container = self.get_container(name)
+        return container.id if container else None
 
-    def get_logs(self, container_name: str, tail: int = 10, **kwargs: Any) -> str:
+    def get_container_status(self, name: str) -> Optional[str]:
+        """Get container status by name."""
+        container = self.get_container(name)
+        return container.status if container else None
+
+    def get_container_logs(self, name: str, **kwargs) -> Iterable[str]:
         """Get container logs."""
         try:
-            container = self.get_container(container_name)
+            container = self.get_container(name)
             if container is None:
-                return ""
+                return iter([])
 
-            return container.logs(tail=tail).decode("utf-8")
+            for line in container.logs(stream=True):
+                yield line.decode("utf-8")
         except (docker.errors.APIError, docker.errors.DockerException) as exc:
             logger.error(f"Failed to get container logs: {exc}")
-            raise exc
-
-    def get_ports(self, container_name: str) -> Dict[int, int]:
-        """Get container ports."""
-        try:
-            container = self.get_container(container_name)
-            if container is None:
-                return {}
-            return {container_p: host_p.get("HostPort") for container_p, host_p in container.ports.items()}
-        except (docker.errors.APIError, docker.errors.DockerException) as exc:
-            logger.error(f"Failed to get container ports: {exc}")
             raise exc

--- a/nos/test/conftest.py
+++ b/nos/test/conftest.py
@@ -74,14 +74,14 @@ def grpc_client_gpu():
     """Test gRPC client to be used with GPU docker runtime (Port: 50054)."""
     from nos.client import InferenceClient
 
-    yield InferenceClient(f"localhost:{GRPC_TEST_PORT_GPU}")
+    yield InferenceClient(f"[::]:{GRPC_TEST_PORT_GPU}")
 
 
 @pytest.fixture(scope="session")
 def grpc_server_docker_runtime_cpu():
     """Test DockerRuntime CPU (Port: 50053)."""
     from nos.server.docker import DockerRuntime
-    from nos.server.runtime import NOS_DOCKER_IMAGE_CPU, NOS_GRPC_SERVER_CMD
+    from nos.server.runtime import NOS_DOCKER_IMAGE_CPU, NOS_INFERENCE_SERVICE_CMD
 
     docker_runtime = DockerRuntime.get()
 
@@ -94,9 +94,9 @@ def grpc_server_docker_runtime_cpu():
     # Start grpc server runtime (CPU)
     container = docker_runtime.start(
         image=NOS_DOCKER_IMAGE_CPU,
-        container_name=CPU_CONTAINER_NAME,
-        command=[NOS_GRPC_SERVER_CMD],
-        ports={DEFAULT_GRPC_PORT: GRPC_TEST_PORT_CPU},
+        name=CPU_CONTAINER_NAME,
+        command=[NOS_INFERENCE_SERVICE_CMD],
+        ports={f"{DEFAULT_GRPC_PORT}/tcp": GRPC_TEST_PORT_CPU},
         environment={
             "NOS_LOGGING_LEVEL": "DEBUG",
         },
@@ -135,7 +135,7 @@ def grpc_server_docker_runtime_cpu():
 def grpc_server_docker_runtime_gpu():
     """Test DockerRuntime GPU (Port: 50054)."""
     from nos.server.docker import DockerRuntime
-    from nos.server.runtime import NOS_DOCKER_IMAGE_GPU, NOS_GRPC_SERVER_CMD
+    from nos.server.runtime import NOS_DOCKER_IMAGE_GPU, NOS_INFERENCE_SERVICE_CMD
 
     docker_runtime = DockerRuntime.get()
 
@@ -148,9 +148,9 @@ def grpc_server_docker_runtime_gpu():
     # Start grpc server runtime (GPU)
     container = docker_runtime.start(
         image=NOS_DOCKER_IMAGE_GPU,
-        container_name=GPU_CONTAINER_NAME,
-        command=[NOS_GRPC_SERVER_CMD],
-        ports={DEFAULT_GRPC_PORT: GRPC_TEST_PORT_GPU},
+        name=GPU_CONTAINER_NAME,
+        command=[NOS_INFERENCE_SERVICE_CMD],
+        ports={f"{DEFAULT_GRPC_PORT}/tcp": GRPC_TEST_PORT_GPU},
         environment={
             "NOS_LOGGING_LEVEL": "DEBUG",
         },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,10 +135,10 @@ lines-after-imports = 2
 max-complexity = 10
 
 [tool.pytest.ini_options]
-addopts = "-sv -m 'not (skip) and not (client) and not (benchmark) and not (e2e)'"
+addopts = "-sv -m 'not (skip) and not (client) and not (benchmark) and not (server)'"
 markers = [
-    "client", # Client-side tests
-    "e2e", # End-to-end integration tests
+    "client", # Client-side (integration) tests
+    "server", # Server-side tests
     "benchmark", # Benchmark tests that is slow for basic CI
     "asyncio", # Async IO tests
 ]

--- a/tests/cli/test_cli_predict.py
+++ b/tests/cli/test_cli_predict.py
@@ -6,10 +6,10 @@ from nos.test.conftest import grpc_server_docker_runtime_cpu, grpc_server_docker
 from nos.test.utils import NOS_TEST_IMAGE
 
 
+pytestmark = pytest.mark.client
 runner = CliRunner()
 
 
-@pytest.mark.e2e
 def test_cli_predict_list(grpc_server_docker_runtime_cpu):  # noqa: F811
     from nos.test.conftest import GRPC_TEST_PORT_CPU
 
@@ -17,7 +17,6 @@ def test_cli_predict_list(grpc_server_docker_runtime_cpu):  # noqa: F811
     assert result.exit_code == 0
 
 
-@pytest.mark.e2e
 def test_cli_predict_txt2vec(grpc_server_docker_runtime_cpu):  # noqa: F811
     from nos.test.conftest import GRPC_TEST_PORT_CPU
 
@@ -27,7 +26,6 @@ def test_cli_predict_txt2vec(grpc_server_docker_runtime_cpu):  # noqa: F811
     assert result.exit_code == 0
 
 
-@pytest.mark.e2e
 def test_cli_predict_img2vec(grpc_server_docker_runtime_cpu):  # noqa: F811
     from nos.test.conftest import GRPC_TEST_PORT_CPU
 
@@ -37,7 +35,6 @@ def test_cli_predict_img2vec(grpc_server_docker_runtime_cpu):  # noqa: F811
     assert result.exit_code == 0
 
 
-@pytest.mark.e2e
 def test_cli_predict_img2bbox(grpc_server_docker_runtime_gpu):  # noqa: F811
     from nos.test.conftest import GRPC_TEST_PORT_GPU
 
@@ -47,7 +44,6 @@ def test_cli_predict_img2bbox(grpc_server_docker_runtime_gpu):  # noqa: F811
     assert result.exit_code == 0
 
 
-@pytest.mark.e2e
 def test_cli_predict_txt2img(grpc_server_docker_runtime_gpu):  # noqa: F811
     from nos.test.conftest import GRPC_TEST_PORT_GPU
 

--- a/tests/cli/test_cli_system.py
+++ b/tests/cli/test_cli_system.py
@@ -4,10 +4,10 @@ from typer.testing import CliRunner
 from nos.cli.cli import app_cli
 
 
+pytestmark = pytest.mark.client
 runner = CliRunner()
 
 
-@pytest.mark.e2e
 def test_cli_system_info():
     result = runner.invoke(app_cli, ["system", "info"])
     assert result.exit_code == 0

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -1,1 +1,0 @@
-from nos.test.conftest import grpc_server_docker_runtime_cpu, grpc_server_docker_runtime_gpu  # noqa: F401

--- a/tests/server/test_docker_runtime.py
+++ b/tests/server/test_docker_runtime.py
@@ -1,11 +1,14 @@
+import time
+
 import pytest
+from loguru import logger
 
 from nos.server.docker import DockerRuntime
-from nos.server.runtime import NOS_DOCKER_IMAGE_CPU, NOS_DOCKER_IMAGE_GPU, NOS_GRPC_SERVER_CMD
+from nos.server.runtime import NOS_DOCKER_IMAGE_CPU, NOS_DOCKER_IMAGE_GPU
 from nos.test.utils import skip_if_no_torch_cuda
 
 
-pytestmark = pytest.mark.e2e
+pytestmark = pytest.mark.server
 
 
 def test_docker_runtime_singleton():
@@ -15,44 +18,143 @@ def test_docker_runtime_singleton():
     assert docker_runtime is docker_runtime_
 
 
-def test_docker_runtime_cpu(grpc_server_docker_runtime_cpu):
-    """Test DockerRuntime for CPU."""
-    # Try re-starting the container
-    # This should not fail, and should return the existing container
+@pytest.fixture
+def docker_runtime_cpu_container():
+    """Test DockerRuntime CPU."""
     docker_runtime = DockerRuntime.get()
-    container_ = docker_runtime.start(
+
+    container_name = "nos-docker-runtime-cpu-test"
+
+    # Start CPU container
+    container = docker_runtime.start(
         image=NOS_DOCKER_IMAGE_CPU,
-        container_name=grpc_server_docker_runtime_cpu.name,
-        command=[NOS_GRPC_SERVER_CMD],
+        name=container_name,
+        command=r"""bash -c 'echo CPU test && sleep 5'""",
         detach=True,
         gpu=False,
     )
-    assert container_ is not None
-    assert container_.id is not None
-    assert container_.id == grpc_server_docker_runtime_cpu.id
+    logger.debug(f"Starting test CPU container: name={container_name}")
+
+    # Wait for container to start
+    st = time.time()
+    while time.time() - st <= 60:
+        status = docker_runtime.get_container_status(container_name)
+        if status == "running" or status is None:
+            break
+        time.sleep(1)
+        logger.debug(
+            f"Waiting for container to start: name={container_name}, status={status}, elapsed={time.time() - st:.0f}s"
+        )
+    assert status == "running" or status is None
+    logger.debug(f"Started test CPU container: name={container_name}")
+
+    yield container
+
+    # Get container logs
+    logs = list(docker_runtime.get_container_logs(container_name))
+    assert len(logs) > 0
+    logger.debug(f"CPU container logs:\n{''.join(logs)}")
+
+    # Stop container
+    # Note: Once the command is finished, the container will stop automatically.
+    # This just ensures that the container is stopped and removed.
+    logger.debug(f"Stopping test CPU container: name={container_name}")
+    docker_runtime.stop(container_name)
+
+    # Wait for container to stop
+    st = time.time()
+    while time.time() - st <= 60:
+        status = docker_runtime.get_container_status(container_name)
+        if status != "running":
+            break
+        time.sleep(1)
+    assert status != "running" or status is None
+    logger.debug(f"Stopped test CPU container: name={container_name}")
 
 
 @skip_if_no_torch_cuda
-def test_docker_runtime_gpu(grpc_server_docker_runtime_gpu):
-    """Test DockerRuntime for GPU."""
-    # Try re-starting the container
-    # This should not fail, and should return the existing container
+@pytest.fixture
+def docker_runtime_gpu_container():
+    """Test DockerRuntime GPU."""
     docker_runtime = DockerRuntime.get()
-    container_ = docker_runtime.start(
+
+    container_name = "nos-docker-runtime-gpu-test"
+
+    # Start CPU container
+    container = docker_runtime.start(
         image=NOS_DOCKER_IMAGE_GPU,
-        container_name=grpc_server_docker_runtime_gpu.name,
-        command=[NOS_GRPC_SERVER_CMD],
+        name=container_name,
+        command=r"""bash -c 'echo GPU test && nvidia-smi && sleep 5'""",
         detach=True,
         gpu=True,
     )
-    assert container_ is not None
-    assert container_.id is not None
-    assert container_.id == grpc_server_docker_runtime_gpu.id
+    logger.debug(f"Starting test GPU container: name={container_name}")
+
+    # Wait for container to start
+    st = time.time()
+    while time.time() - st <= 60:
+        status = docker_runtime.get_container_status(container_name)
+        if status == "running" or status is None:
+            break
+        time.sleep(1)
+        logger.debug(
+            f"Waiting for container to start: name={container_name}, status={status}, elapsed={time.time() - st:.0f}s"
+        )
+    assert status == "running" or status is None
+    logger.debug(f"Started test GPU container: name={container_name}")
+
+    yield container
+
+    # Get container logs
+    logs = list(docker_runtime.get_container_logs(container_name))
+    assert len(logs) > 0
+    logger.debug(f"GPU container logs:\n{''.join(logs)}")
+
+    # Stop container
+    # Note: Once the command is finished, the container will stop automatically.
+    # This just ensures that the container is stopped and removed.
+    logger.debug(f"Stopping test GPU container: name={container_name}")
+    docker_runtime.stop(container_name)
+
+    # Wait for container to stop
+    st = time.time()
+    while time.time() - st <= 60:
+        status = docker_runtime.get_container_status(container_name)
+        if status != "running":
+            break
+        time.sleep(1)
+    assert status != "running" or status is None
+    logger.debug(f"Stopped test GPU container: name={container_name}")
 
 
-def test_docker_runtime_logs(grpc_server_docker_runtime_cpu):  # noqa: F811
-    """Test Dockerdocker_runtime logs."""
+def test_docker_runtime_cpu(docker_runtime_cpu_container):
+    """Test DockerRuntime for CPU."""
     docker_runtime = DockerRuntime.get()
-    docker_runtime.get_container(grpc_server_docker_runtime_cpu.name)
-    logs = docker_runtime.get_logs(grpc_server_docker_runtime_cpu.name)
-    assert logs is not None
+
+    container = docker_runtime_cpu_container
+    container_name = container.name
+    assert container is not None
+    assert container.id is not None
+    assert docker_runtime.get_container_id(container_name) == container.id
+
+    # Get CPU container
+    container_ = docker_runtime.get_container(container_name)
+    assert container_ is not None
+    assert container_.id == container.id
+
+
+@skip_if_no_torch_cuda
+def test_docker_runtime_gpu(docker_runtime_gpu_container):
+    """Test DockerRuntime for GPU."""
+    docker_runtime = DockerRuntime.get()
+
+    container = docker_runtime_gpu_container
+    container_name = container.name
+    assert container is not None
+    assert container.id is not None
+    assert docker_runtime.get_container_id(container_name) == container.id
+
+    # Get GPU container
+    container_ = docker_runtime.get_container(container_name)
+    assert container_ is not None
+    assert container_.id == container.id

--- a/tests/server/test_inference_service.py
+++ b/tests/server/test_inference_service.py
@@ -5,7 +5,7 @@ from nos.server.service import InferenceServiceImpl
 from nos.test.conftest import ray_executor  # noqa: F401
 
 
-pytestmark = pytest.mark.e2e
+pytestmark = pytest.mark.server
 
 
 @pytest.mark.skip(reason="This test is not ready yet.")

--- a/tests/server/test_inference_service_runtime.py
+++ b/tests/server/test_inference_service_runtime.py
@@ -1,15 +1,60 @@
+import time
+
 import pytest
+from loguru import logger
 
+from nos.constants import DEFAULT_GRPC_PORT
 from nos.server.runtime import InferenceServiceRuntime
+from nos.test.utils import skip_if_no_torch_cuda
 
 
-pytestmark = pytest.mark.e2e
+pytestmark = pytest.mark.server
 
 
-def test_inference_service_runtime():  # noqa: F811
-    runtime = InferenceServiceRuntime()
+@pytest.fixture
+def inference_service_runtime_cpu():
+    runtime = InferenceServiceRuntime(runtime="cpu", name="nos-inference-service-runtime-cpu-test")
     assert runtime is not None
 
-    runtime.start()
-    assert runtime.id is not None
+    logger.debug("Starting inference service runtime: cpu")
+    runtime.start(ports={f"{DEFAULT_GRPC_PORT-1}/tcp": DEFAULT_GRPC_PORT - 1})
+    assert runtime.get_container() is not None
+    assert runtime.get_container_id() is not None
+    assert runtime.get_container_name() is not None
+    assert runtime.get_container_status() is not None
+
+    yield runtime
+
+    logger.debug("Stopping inference service runtime: cpu")
     runtime.stop()
+    logger.debug("Stopped inference service runtime: cpu")
+
+
+@skip_if_no_torch_cuda
+@pytest.fixture
+def inference_service_runtime_gpu():
+    runtime = InferenceServiceRuntime(runtime="gpu", name="nos-inference-service-runtime-gpu-test")
+    assert runtime is not None
+
+    logger.debug("Starting inference service runtime: gpu")
+    runtime.start(ports={f"{DEFAULT_GRPC_PORT-2}/tcp": DEFAULT_GRPC_PORT - 2})
+    assert runtime.get_container() is not None
+    assert runtime.get_container_id() is not None
+    assert runtime.get_container_name() is not None
+    assert runtime.get_container_status() is not None
+
+    yield runtime
+    logger.debug("Stopping inference service runtime: gpu")
+    runtime.stop()
+    logger.debug("Stopped inference service runtime: gpu")
+
+
+def test_inference_service_runtime_cpu(inference_service_runtime_cpu):  # noqa: F811
+    assert inference_service_runtime_cpu is not None
+    time.sleep(5)
+
+
+@skip_if_no_torch_cuda
+def test_inference_service_runtime_gpu(inference_service_runtime_gpu):  # noqa: F811
+    assert inference_service_runtime_gpu is not None
+    time.sleep(5)


### PR DESCRIPTION
## Summary

This commit refactors the `InferenceServiceRuntime` and `DockerRuntime` classes.
 - removed most kwargs from `DockerRuntime.start(...)`, instead passes along kwargs to `docker_client.containers.run(...)`.
 - added new `InferenceServiceRuntimeConfig` for defining custom configurations (i.e. for CPU/GPU, runtime/build etc) with the `configs` dictionary in `InferenceServiceRuntime`.
 - improved testing reliability for `test_docker_runtime.py`. The `docker_runtime.stop()` force removes the container and fails gracefully if the container has already exited.
 - improved `test_inference_service_runtime` to test the different configurations defined in the `configs` dictionary.

## Related issues

#112 

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
