### PR TITLE
Simplify server-side task dispatch without switch-case

### DIFF
--- a/nos/client/grpc.py
+++ b/nos/client/grpc.py
@@ -203,7 +203,6 @@ class InferenceClient:
                     request=nos_service_pb2.ModelInfo(task=spec.task.value, name=spec.name)
                 )
             )
-            logger.debug(response)
             model_spec: ModelSpec = loads(response.response_bytes)
             return model_spec
         except grpc.RpcError as e:
@@ -302,14 +301,14 @@ class InferenceModule:
         """Get the relevant model information from the model name."""
         return self._spec
 
-    def __call__(self, **inputs: Dict[str, Any]) -> nos_service_pb2.InferenceResponse:
+    def __call__(self, **inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Call the instantiated module/model.
 
         Args:
             **inputs (Dict[str, Any]): Inputs to the model ("images", "texts", "prompts" etc) as
                 defined in the ModelSpec.signature.inputs.
         Returns:
-            nos_service_pb2.InferenceResponse: Inference response.
+            Dict[str, Any]: Inference response.
         Raises:
             NosClientException: If the server fails to respond to the request.
         """
@@ -325,9 +324,9 @@ class InferenceModule:
             inputs=inputs,
         )
         try:
+
             response = self.stub.Run(request)
             response = loads(response.response_bytes)
-            logger.debug(response)
             return response
         except grpc.RpcError as e:
             raise NosClientException(f"Failed to run model {self.model_name} ({e})")


### PR DESCRIPTION
## Summary

This PR simplifies the server-side task dispatch to the various model-specific handlers, instead of having to use a switch case. The function signatures are used to dispatch and return the appropriate response to the client.

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
