### PR TITLE
ModelSpec serialization `to_proto` bugfix

### DIFF
--- a/nos/common/spec.py
+++ b/nos/common/spec.py
@@ -224,12 +224,17 @@ class ModelSpec:
         """Convert the model spec to proto."""
         if public:
             spec = copy.deepcopy(self)
-            spec.func_or_cls = None
-            spec.init_args = ()
-            spec.init_kwargs = {}
-            spec.method_name = None
+            spec.signature.func_or_cls = None
+            spec.signature.init_args = ()
+            spec.signature.init_kwargs = {}
+            spec.signature.method_name = None
         else:
             spec = self
         return nos_service_pb2.ModelInfoResponse(
             response_bytes=dumps(spec),
         )
+
+    @staticmethod
+    def _from_proto(minfo: nos_service_pb2.ModelInfoResponse) -> "ModelSpec":
+        """Convert the model info response back to the spec."""
+        return loads(minfo.response_bytes)

--- a/tests/common/test_common_spec.py
+++ b/tests/common/test_common_spec.py
@@ -103,6 +103,20 @@ def test_common_model_spec(img2vec_signature):
     )
     assert spec is not None
 
+    # Test serialization
+    minfo = spec._to_proto()
+    spec_ = ModelSpec._from_proto(minfo)
+    assert spec_.signature.inputs is not None
+    assert spec_.signature.outputs is not None
+    assert spec_.signature.func_or_cls is not None
+
+    # Test serialization (public)
+    minfo = spec._to_proto(public=True)
+    spec_ = ModelSpec._from_proto(minfo)
+    assert spec_.signature.inputs is not None
+    assert spec_.signature.outputs is not None
+    assert spec_.signature.func_or_cls is None
+
     # Create a model spec with a wrong method name
     with pytest.raises(ValidationError):
         spec = ModelSpec(


### PR DESCRIPTION
## Summary

This fixes the issue where the `to_proto` method of `ModelSpec` was not serializing the `signature` field correctly. We have to set the internal fields to `None` (for the time-being) so that only the `inputs` and `outputs` fields are serialized for public consumption.

- added test for ser-de `_to_proto` and `_from_proto` methods

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
