### PR TITLE
Basic opencv-based video reader for I/O

### DIFF
--- a/nos/common/io/__init__.py
+++ b/nos/common/io/__init__.py
@@ -1,0 +1,1 @@
+from .video.opencv import VideoFile  # noqa: F401

--- a/nos/common/io/video/base.py
+++ b/nos/common/io/video/base.py
@@ -1,0 +1,47 @@
+"""Simple video reader."""
+from abc import ABC, abstractmethod
+from typing import Iterator, Optional, TypeVar
+
+
+T = TypeVar("T")
+
+
+class BaseVideoFile(ABC):
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__} [fn={self.filename}]"
+
+    @abstractmethod
+    def __len__(self) -> int:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def __iter__(self) -> Iterator[T]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def __next__(self) -> T:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def __getitem__(self, idx: int) -> T:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def open(self) -> T:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def close(self) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def pos(self) -> Optional[int]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def seek(self, idx: int) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def reset(self) -> None:
+        self.seek(0)

--- a/nos/common/io/video/opencv.py
+++ b/nos/common/io/video/opencv.py
@@ -1,0 +1,131 @@
+from pathlib import Path
+from typing import Callable, Iterator, List, Optional, Union
+
+import cv2
+import numpy as np
+
+from nos.common.io.video.base import BaseVideoFile
+
+
+T = np.ndarray
+
+
+class VideoFile(BaseVideoFile):
+    """Video Reader with OpenCV backend."""
+
+    def __init__(self, filename: Union[str, Path], transform: Optional[Callable] = None, bridge: str = "numpy"):
+        """Initialize video reader.
+
+        Args:
+            filename (Union[str, Path]): The path to the video file.
+            transform (Optional[Callable], optional): A function to apply to each frame. Defaults to None.
+            bridge (str, optional): The bridge type to use. Defaults to "numpy". Options are ("numpy", "torch").
+        Raises:
+            FileNotFoundError: If the video file does not exist.
+            NotImplementedError: If the bridge type is not supported.
+        """
+        super().__init__()
+        self.filename = Path(str(filename))
+        if not self.filename.exists():
+            raise FileNotFoundError(f"{self.filename} does not exist")
+        self.transform = transform
+        # TODO (spillai): Add support for torch bridge
+        if bridge not in ("numpy",):
+            raise NotImplementedError(f"Unknown bridge type {bridge}")
+        self.bridge = bridge
+        self._video = self.open()
+
+    def __len__(self) -> int:
+        """Return the number of frames in the video.
+
+        Returns:
+            int: The number of frames in the video.
+        """
+        return int(self._video.get(cv2.CAP_PROP_FRAME_COUNT))
+
+    def __iter__(self) -> Iterator[T]:
+        """Return an iterator over the video.
+
+        Returns:
+            Iterator[T]: An iterator over the video.
+        """
+        return self
+
+    def __next__(self) -> T:
+        """Return the next frame in the video.
+
+        Raises:
+            StopIteration: If there are no more frames in the video.
+        Returns:
+            T: The next frame in the video.
+        """
+        ret, img = self._video.read()
+        if ret is False:
+            raise StopIteration()
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        if self.transform:
+            img = self.transform(img)
+        return img
+
+    def __getitem__(self, idx: Union[T, List[int], int]) -> Union[T, List[T]]:
+        """Return the frame or frame(s) at the given index/indices.
+
+        Args:
+            idx (Union[T, List[int], int]): The index or indices to return.
+        Raises:
+            IndexError: If the index is out of bounds.
+        Returns:
+            Union[T, List[T]]: The frame or frame(s) at the given index/indices.
+        """
+        if isinstance(idx, (int, np.int32, np.int64)):
+            self.seek(idx)
+            return next(self)
+        elif isinstance(idx, (T, List)):
+            return [self.__getitem__(ind) for ind in idx]
+        else:
+            raise TypeError(f"Unknown type for {idx}, type={type(idx)}")
+
+    def open(self) -> cv2.VideoCapture:
+        """Open the video file.
+
+        Raises:
+            RuntimeError: If the video file cannot be opened.
+        Returns:
+            cv2.VideoCapture: The opened video file.
+        """
+        video = cv2.VideoCapture(str(self.filename))
+        if not video.isOpened():
+            raise RuntimeError(f"{self.__class__.__name__} :: Failed to open {self.filename}")
+        return video
+
+    def close(self) -> None:
+        """Close the video file."""
+        self._video.release()
+        self._video = None
+
+    def pos(self) -> Optional[int]:
+        """Return the current position in the video.
+
+        Returns:
+            Optional[int]: The current position in the video.
+        """
+        try:
+            return int(self._video.get(cv2.CAP_PROP_POS_FRAMES))
+        except Exception:
+            return None
+
+    def seek(self, idx: int) -> None:
+        """Seek to the given index in the video.
+
+        Args:
+            idx (int): The index to seek to.
+        Raises:
+            IndexError: If the index is out of bounds.
+        """
+        if idx < 0 or idx >= len(self):
+            raise IndexError(f"Invalid index {idx}")
+        self._video.set(cv2.CAP_PROP_POS_FRAMES, idx)
+
+    def reset(self) -> None:
+        """Reset the video to the beginning."""
+        self.seek(0)

--- a/tests/common/io/video/test_opencv.py
+++ b/tests/common/io/video/test_opencv.py
@@ -1,0 +1,123 @@
+import numpy as np
+import pytest
+from loguru import logger
+
+from nos.common.io import VideoFile
+from nos.test.utils import NOS_TEST_VIDEO
+
+
+VIDEO_FILES = [NOS_TEST_VIDEO]
+
+
+@pytest.mark.parametrize("filename", VIDEO_FILES)
+def test_video(filename):
+    from itertools import islice
+
+    logger.info(f"Testing video {filename}")
+    video = VideoFile(filename)
+
+    # Test len()
+    assert len(video) > 0
+
+    # Test __getitem__()
+    indices = np.random.choice(np.arange(len(video)), size=min(5, len(video)), replace=False)
+    for index in indices:
+        img = video[index]
+        assert isinstance(img, np.ndarray)
+
+    # Test __getitem__() with np.int
+    imgs = video[indices]
+    assert isinstance(imgs, list)
+
+    # Test __getitem__() with list
+    imgs = video[indices.tolist()]
+    assert isinstance(imgs, list)
+
+    # Reset
+    video.reset()
+    assert video.pos() == 0
+
+    # Test iterator
+    for img in islice(video, 0, 10):
+        assert isinstance(img, np.ndarray)
+
+    # Seek to a random position and test pos()
+    video.seek(1)
+    assert video.pos() == 1
+
+    # Test invalid file
+    with pytest.raises(FileNotFoundError):
+        VideoFile("does_not_exist.mp4")
+
+    # Test invalid bridge
+    with pytest.raises(NotImplementedError):
+        VideoFile(filename, bridge="invalid_bridge")
+
+    # Test out-of-bounds seek
+    with pytest.raises(IndexError):
+        video.seek(len(video) + 1)
+
+    # Test __getitem__() with invalid types
+    with pytest.raises(TypeError):
+        video["invalid_index"]
+
+    # Test __getitem__() with invalid index
+    with pytest.raises(IndexError):
+        video[len(video) + 1]
+
+    # Test next() StopIteration after seeking to the end
+    video.seek(len(video) - 1)
+    img = next(video)
+    with pytest.raises(StopIteration):
+        next(video)
+
+
+@pytest.mark.skip(reason="Not implemented")
+def test_video_context_manager():
+    with VideoFile(NOS_TEST_VIDEO) as video:
+        assert len(video) > 0
+        img = next(video)
+        assert isinstance(img, np.ndarray)
+
+
+@pytest.mark.parametrize("filename", VIDEO_FILES)
+def test_video_bridge(filename):
+
+    for (bridge, instance_type) in [
+        ("numpy", np.ndarray),
+    ]:
+        video = VideoFile(filename, bridge=bridge)
+        assert len(video) > 0
+        img = next(video)
+        assert isinstance(img, instance_type)
+
+
+@pytest.mark.benchmark
+def test_benchmark_video_loading():
+    import time
+
+    import requests
+    from tqdm import tqdm
+
+    from nos.constants import NOS_CACHE_DIR
+
+    URL = "https://zackakil.github.io/video-intelligence-api-visualiser/assets/test_video.mp4"
+
+    # Download video from URL to local file
+    tmp_videos_dir = NOS_CACHE_DIR / "test_data" / "videos"
+    tmp_videos_dir.mkdir(parents=True, exist_ok=True)
+    tmp_video_filename = tmp_videos_dir / "test_video.mp4"
+    if not tmp_video_filename.exists():
+        with open(str(tmp_video_filename), "wb") as f:
+            f.write(requests.get(URL).content)
+        assert tmp_video_filename.exists()
+
+    # Test video loading
+    video = VideoFile(tmp_video_filename)
+    st = time.perf_counter()
+    for img in tqdm(video):
+        assert isinstance(img, np.ndarray)
+    end = time.perf_counter()
+    logger.info(
+        f"VideoFile:: nframes={len(video)}, shape={img.shape}, elapsed={end - st:.2f}s, fps={len(video) / (end-st):.1f}fps"
+    )


### PR DESCRIPTION
## Summary

This is a basic video reader that uses opencv to read video files in a streaming fashion. We will need this to benchmark the performance of batched inference on video files.

Initial benchmark tests indicate ~700fps for 720p video.
```bash
test_opencv:test_benchmark_video_loading:113 - VideoFile:: nframes=6059, shape=(720, 1280, 3), elapsed=8.72s, fps=695.1fps
```
## Related issues
This PR is needed to simplify batched inference: #135 #136 

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [x] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
