### PR TITLE
Shared memory transport for gRPC

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -15,7 +15,7 @@ services:
     environment:
       - NOS_HOME=/app/.nos
       - NOS_LOGGING_LEVEL=DEBUG
+      - NOS_SHM_ENABLED=1
     volumes:
       - ~/.nosd:/app/.nos
-      - /tmp:/tmp
-    shm_size: 4G
+      - /dev/shm:/dev/shm

--- a/docker-compose.extras.yml
+++ b/docker-compose.extras.yml
@@ -4,9 +4,10 @@ x-nos-common:
   &nos-common
   volumes:
     - ~/.nosd:/app/.nos
+    - /dev/shm:/dev/shm
   environment:
     - NOS_LOGGING=DEBUG
-  shm_size: 4G
+    - NOS_SHM_ENABLED=1
 
 x-nos-gpu:
   &nos-common-gpu
@@ -27,10 +28,6 @@ services:
         - TARGET=gpu
         - DOCKER_TARGET=base
         - BASE_IMAGE=nvidia/cuda:11.8.0-base-ubuntu22.04
-    volumes:
-    - ~/.nosd:/app/.nos
-    environment:
-      - NOS_CONDA_ENV=nos_trt
 
   mmdet-dev:
     <<: [*nos-common, *nos-common-gpu]

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -15,9 +15,10 @@ services:
     environment:
       - NOS_HOME=/app/.nos
       - NOS_LOGGING_LEVEL=DEBUG
+      - NOS_SHM_ENABLED=1
     volumes:
       - ~/.nosd:/app/.nos
-    shm_size: 4G
+      - /dev/shm:/dev/shm
     deploy:
       resources:
         reservations:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,9 +4,10 @@ x-nos-common:
   &nos-common-test
   volumes:
     - ~/.nosd:/app/.nos
+    - /dev/shm:/dev/shm
   environment:
     - NOS_LOGGING=DEBUG
-  shm_size: 4G
+    - NOS_SHM_ENABLED=1
 
 x-nos-gpu:
   &nos-common-gpu-test

--- a/examples/quickstart/docker-compose.quickstart.yml
+++ b/examples/quickstart/docker-compose.quickstart.yml
@@ -8,7 +8,8 @@ services:
       - 50051:50051
     environment:
       - NOS_HOME=/app/.nos
+      - NOS_SHM_ENABLED=1
       - NOS_LOGGING_LEVEL=ERROR
     volumes:
       - ~/.nosd:/app/.nos
-    shm_size: 4G
+      - /dev/shm:/dev/shm

--- a/nos/common/__init__.py
+++ b/nos/common/__init__.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from .cloudpickle import dumps, loads
+from .shm import SharedMemoryDataDict, SharedMemoryNumpyObject, SharedMemoryTransportManager  # noqa: F401
 from .spec import FunctionSignature, ModelSpec, ObjectTypeInfo  # noqa: F401
 from .tasks import TaskType  # noqa: F401
 from .types import Batch, EmbeddingSpec, ImageSpec, ImageT, TensorSpec, TensorT  # noqa: F401

--- a/nos/common/shm.py
+++ b/nos/common/shm.py
@@ -1,0 +1,190 @@
+import os
+from dataclasses import dataclass, field
+from multiprocessing.managers import SharedMemoryManager
+from multiprocessing.shared_memory import SharedMemory
+from typing import Any, Dict, Tuple
+
+import numpy as np
+
+from nos.common.cloudpickle import dumps, loads
+from nos.common.types import TensorSpec
+from nos.logging import logger
+
+
+NOS_SHM_ENABLED = bool(int(os.environ.get("NOS_SHM_ENABLED", 0)))
+
+
+@dataclass
+class SharedMemoryNumpyObject:
+    """Shared memory object wrapping numpy array."""
+
+    shm: SharedMemory
+    """Shared memory object"""
+    shape: Tuple[int, ...]
+    """numpy array shape"""
+    dtype: str
+    """numpy array dtype"""
+
+    def __repr__(self) -> str:
+        """Return the shared memory object representation."""
+        return f"SharedMemoryNumpyObject(name={self.name}, shape={self.shape}, dtype={self.dtype})"
+
+    def __getstate__(self) -> Dict[str, Any]:
+        """Return the shared memory object state."""
+        return {"name": self.name, "shape": self.shape, "dtype": self.dtype}
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        """Set the shared memory object state."""
+        self.__init__(SharedMemory(name=state["name"]), state["shape"], state["dtype"])
+
+    def __del__(self) -> None:
+        """Close the shared memory object."""
+        self.shm.close()
+
+    @property
+    def name(self) -> str:
+        """Return the shared memory name."""
+        return self.shm.name
+
+    def copy(self, arr: np.ndarray) -> None:
+        """Copy the numpy array to shared memory object."""
+        assert arr.shape == self.shape, f"Array shape {arr.shape} does not match shared memory shape {self.shape}"
+        assert arr.dtype == self.dtype, f"Array dtype {arr.dtype} does not match shared memory dtype {self.dtype}"
+        target = np.ndarray(arr.shape, dtype=arr.dtype, buffer=self.shm.buf)
+        target[:] = arr[:]
+
+    def get(self) -> np.ndarray:
+        """Get the numpy array from the shared memory object ."""
+        src = np.ndarray(shape=self.shape, dtype=getattr(np, self.dtype), buffer=self.shm.buf)
+        target = src.copy()
+        del src
+        return target
+
+
+class SharedMemoryDataDict:
+    """Shared-memory data wrapper."""
+
+    @staticmethod
+    def decode(data: Dict[str, Any]) -> Dict[str, Any]:
+        """Decode the data dictionary with shared-memory references.
+
+        Note: First unpickle the data bytes, then replace the shared-memory references
+        with numpy arrays. SharedMemoryNumpyObject have a custom __getstate__ method
+        that returns the shared-memory name, shape and dtype. The __setstate__ method
+        is called when the object is unpickled, and it creates a new SharedMemoryNumpyObject
+        instance with the given name, shape and dtype.
+        """
+        data = {k: loads(v) for k, v in data.items()}
+        if NOS_SHM_ENABLED:
+            logger.debug("Decoding shared memory data")
+            for k, v in data.items():
+                if isinstance(v, SharedMemoryNumpyObject):
+                    data[k] = v.get()
+                    logger.debug(f"Decoded data: {k}, {type(data[k])}, {data[k].shape}")
+                elif isinstance(v, list) and isinstance(v[0], SharedMemoryNumpyObject):
+                    data[k] = [x.get() for x in v]
+                    logger.debug(f"Decoded data: {k}, {type(data[k][0])}, {data[k][0].shape}")
+        return data
+
+    @staticmethod
+    def encode(data: Dict[str, Any]) -> Dict[str, Any]:
+        """Encode the data dictionary with shared-memory references."""
+        return {k: dumps(v) for k, v in data.items()}
+
+
+@dataclass
+class SharedMemoryTransportManager:
+    """Shared memory transport manager."""
+
+    _manager: SharedMemoryManager = field(init=False)
+    """Shared memory manager."""
+    _objects_map: Dict[str, SharedMemory] = field(default_factory=dict)
+    """Shared memory objects map."""
+
+    def __post_init__(self):
+        self._manager = SharedMemoryManager()
+        self._manager.start()
+
+    def __del__(self):
+        """Clean up the shared memory."""
+        self._manager.shutdown()
+
+    def create(self, data: Dict[str, Any], namespace: str = "") -> Dict[str, Any]:
+        """Create a shared memory segment for the data dictionary.
+
+        Args:
+            data (Dict[str, Any]): Inputs to the model ("images", "texts", "prompts" etc) as
+                a dictionary of numpy arrays.
+            namespace (str, optional): Unique namespace for the shared memory segment. Defaults to "".
+        Returns:
+            Dict[str, Any]: Shared memory segment for the data dictionary.
+        """
+        assert len(self._objects_map) == 0, "Shared memory segments should be empty."
+
+        # Create shared memory segments for numpy arrays (or lists of numpy arrays)
+        objects_map = {}
+        for key, value in data.items():
+            # Note (spillai): Assumes all items in the list are numpy arrays of the same shape.
+            if isinstance(value, TensorSpec) or (isinstance(value, list) and isinstance(value[0], TensorSpec)):
+                if isinstance(value, list):
+                    nbytes = value[0].nbytes * len(value)
+                    shape, dtype = value[0].shape, value[0].dtype
+                    objects_map[key] = [
+                        SharedMemoryNumpyObject(self._manager.SharedMemory(item.nbytes), item.shape, str(dtype))
+                        for item in value
+                    ]
+                    logger.debug(
+                        f"Created shm segment: key={f'{id}/{key}'}, size={nbytes / 1024 / 1024:.2f} MB, shape={shape}, dtype={dtype}, len={len(value)}"
+                    )
+                elif isinstance(value, TensorSpec):
+                    nbytes = value.nbytes
+                    shape, dtype = value.shape, value.dtype
+                    objects_map[key] = SharedMemoryNumpyObject(
+                        self._manager.SharedMemory(value.nbytes), value.shape, str(dtype)
+                    )
+                    logger.debug(
+                        f"Created shm segment: key={f'{id}/{key}'}, size={nbytes / 1024 / 1024:.2f} MB, shape={shape}, dtype={dtype}, len=1"
+                    )
+                else:
+                    raise ValueError(f"Unsupported type: {type(value)}")
+
+        self._objects_map.update({f"{namespace}/{k}": v for k, v in objects_map.items()})
+        return objects_map
+
+    def cleanup(self, namespace: str = ""):
+        """Cleanup the shared memory segments."""
+        for key in list(self._objects_map.keys()):
+            if namespace == "" or key.startswith(namespace):
+                del self._objects_map[key]
+
+    @staticmethod
+    def copy_to(shm_map: Dict[str, SharedMemory], data: Dict[str, Any]) -> Dict[str, Any]:
+        """Copy the data dict values to the shared memory segments for transport.
+
+        Args:
+            data (Dict[str, Any]): Inputs to the model ("images", "texts", "prompts" etc) as
+                numpy arrays or lists of numpy arrays.
+        Returns:
+            Dict[str, Any]: Shared memory segments for the data dict values.
+        """
+        assert len(shm_map) > 0, "Shared memory segments should not be empty."
+        assert len(data) > 0, "Data dict should not be empty."
+
+        # Copy the data dict values to the shared memory segments.
+        for key, value in data.items():
+            if key in shm_map:
+                if isinstance(value, list):
+                    if len(value) != len(shm_map[key]):
+                        raise ValueError(
+                            f"Shared memory already initialized with length={len(shm_map[key])}, provided input with length={len(value)}."
+                        )
+                    for item, shm in zip(value, shm_map[key]):
+                        shm.copy(item)
+                elif isinstance(value, np.ndarray):
+                    shm_map[key].copy(value)
+                else:
+                    raise ValueError(f"Unsupported type: {type(value)}")
+                # Overwrite the data dict value with the shared memory segments for transport.
+                data[key] = shm_map[key]
+        logger.debug(f"Successfully copied inputs to shared memory: {shm_map.keys()}")
+        return data

--- a/nos/common/types.py
+++ b/nos/common/types.py
@@ -36,6 +36,14 @@ class TensorSpec:
     dtype: str = None
     """Tensor dtype. (uint8, int32, int64, float32, float64)"""
 
+    @property
+    def nbytes(self) -> Optional[int]:
+        """Return the number of bytes required to store the tensor."""
+        try:
+            return np.prod(self.shape) * np.dtype(self.dtype).itemsize
+        except TypeError:
+            return None
+
     @validator("shape")
     def validate_shape(cls, shape: Optional[Tuple[Optional[int], ...]]):
         """Validate the shape."""

--- a/nos/managers/__init__.py
+++ b/nos/managers/__init__.py
@@ -1,0 +1,1 @@
+from .model import ModelHandle, ModelManager  # noqa: F401

--- a/nos/managers/model.py
+++ b/nos/managers/model.py
@@ -1,0 +1,214 @@
+import os
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List, Union
+
+import ray
+import torch
+
+from nos.common import ModelSpec
+from nos.logging import logger
+
+
+@dataclass
+class ModelHandle:
+    """Model handles for model execution.
+
+    Usage:
+        ```python
+        # Initialize a model handle
+        >> model_handle = ModelHandle(spec, num_replicas=1)
+
+        # Submit a task to the model handle
+        >> handler = model_handle.handle
+        >> response_ref = handler.submit(**model_inputs)
+
+        # Kill all actors
+        >> model_handle.kill()
+        ```
+    """
+
+    spec: ModelSpec
+    """Model specification."""
+    num_replicas: Union[int, str] = field(default=1)
+    """Number of replicas."""
+    _actors: List[Union[ray.remote, ray.actor.ActorHandle]] = field(init=False, default=None)
+    """Ray actor handle."""
+    _actor_method_func: Union[ray.remote, ray.actor.ActorHandle] = field(init=False, default=None)
+    """Ray actor method function."""
+
+    def __post_init__(self):
+        """Initialize the actor handles."""
+        if self.num_replicas > 1:
+            raise NotImplementedError("Multiple replicas not yet supported.")
+        self._actors = [self.actor_from_spec(self.spec) for _ in range(self.num_replicas)]
+        # Get the method function (i.e. `__call__`, or `predict`)
+        try:
+            self._actor_method_func = getattr(self.actor_handle, self.spec.signature.method_name)
+        except AttributeError as exc:
+            self._actor_method_func = None
+            err = f"Failed to get method function: method={self.spec.signature.method_name}"
+            logger.error(f"{err}, exc={exc}")
+            raise Exception(err)
+
+    @staticmethod
+    def actor_from_spec(spec: ModelSpec) -> Union[ray.remote, ray.actor.ActorHandle]:
+        """Get an actor handle from model specification.
+
+        Args:
+            spec (ModelSpec): Model specification.
+        Returns:
+            Union[ray.remote, ray.actor.ActorHandle]: Ray actor handle.
+        """
+        # TODO (spillai): Use the auto-tuned model spec to instantiate an
+        # actor the desired memory requirements. Fractional GPU amounts
+        # will need to be calculated from the target HW and model spec
+        # (i.e. 0.5 on A100 vs. T4 are different).
+        model_cls = spec.signature.func_or_cls
+        actor_options = {"num_gpus": 0.5 if torch.cuda.is_available() else 0}
+        logger.debug(f"Creating actor: {actor_options}, {model_cls}")
+        actor_cls = ray.remote(**actor_options)(model_cls)
+        return actor_cls.remote(*spec.signature.init_args, **spec.signature.init_kwargs)
+
+    def kill(self) -> None:
+        """Kill the actor handle."""
+        for actor_handle in self._actors:
+            ray.kill(actor_handle)
+
+    def remote(self, *args, **kwargs) -> ray.ObjectRef:
+        """Submit a task to the actor handle or pool.
+
+        Args:
+            *args: Variable length argument list.
+            **kwargs: Arbitrary keyword arguments.
+        Returns:
+            ray.ObjectRef: Ray object reference.
+        """
+        # Call the method function
+        response_ref: ray.ObjectRef = self._actor_method_func.remote(**kwargs)
+        return ray.get(response_ref)
+
+    @property
+    def actor_handle(self) -> Union[ray.remote, ray.actor.ActorHandle]:
+        """Get the actor handle."""
+        assert len(self._actors) == 1, "Only one actor handle is supported."
+        return self._actors[0]
+
+
+@dataclass(frozen=True)
+class ModelManager:
+    """Model manager for serving models with ray actors.
+
+    Features:
+      * Concurrency: Support fixed number of concurrent models,
+        running simultaneously with FIFO model eviction policies.
+      * Parallelism: Support multiple replicas of the same model.
+      * Optimal memory management: Model memory consumption
+        are automatically inferred from the model specification
+        and used to optimally bin-pack models on the GPU.
+      * Automatic garbage collection: Models are automatically
+        garbage collected when they are evicted from the manager.
+        Scaling models with the model manager should not result in OOM.
+
+    """
+
+    class EvictionPolicy(str, Enum):
+        FIFO = "FIFO"
+        LRU = "LRU"
+
+    policy: EvictionPolicy = EvictionPolicy.FIFO
+    """Eviction policy."""
+
+    max_concurrent_models: int = os.getenv("NOS_MAX_CONCURRENT_MODELS", 4)
+    """Maximum number of concurrent models."""
+
+    handlers: Dict[str, ModelHandle] = field(default_factory=OrderedDict)
+    """Model handles."""
+
+    def __post_init__(self):
+        if self.policy not in (self.EvictionPolicy.FIFO,):
+            raise NotImplementedError(f"Eviction policy not implemented: {self.policy}")
+
+    def __repr__(self) -> str:
+        """String representation of the model manager (memory consumption, models, in tabular format etc)."""
+        repr_str = f"ModelManager(policy={self.policy}, len(handlers)={len(self.handlers)})"
+        for idx, (model_id, model_handle) in enumerate(self.handlers.items()):
+            repr_str += f"\n\t{idx}: {model_id}, {model_handle}"
+        return repr_str
+
+    def __contains__(self, spec: ModelSpec) -> bool:
+        """Check if a model exists in the manager.
+
+        Args:
+            spec (ModelSpec): Model specification.
+        Returns:
+            bool: True if the model exists, else False.
+        """
+        return spec.id in self.handlers
+
+    def get(self, model_spec: ModelSpec) -> ModelHandle:
+        """Get a model handle from the manager.
+
+        Create a new model handle if it does not exist,
+        else return an existing handle.
+
+        Args:
+            model_spec (ModelSpec): Model specification.
+        Returns:
+            ModelHandle: Model handle.
+        """
+        model_id: str = model_spec.id
+        if model_id not in self.handlers:
+            return self.add(model_spec)
+        else:
+            return self.handlers[model_id]
+
+    def add(self, spec: ModelSpec) -> ModelHandle:
+        """Add a model to the manager.
+
+        Args:
+            spec (ModelSpec): Model specification.
+        Raises:
+            ValueError: If the model already exists.
+        Returns:
+            ModelHandle: Model handle.
+        """
+        # If the model already exists, raise an error
+        model_id = spec.id
+        if model_id in self.handlers:
+            raise ValueError(f"Model already exists: {model_id}")
+
+        # If the model handle is full, pop the oldest model
+        if len(self.handlers) >= self.max_concurrent_models:
+            _handle: ModelHandle = self.evict()
+            logger.debug(f"Deleting oldest model: {_handle.spec.name}")
+
+        # Create the serve deployment from the model handle
+        logger.debug(f"Initializing model with spec: {spec.name}")
+
+        # Note: Currently one model per (model-name, task) is supported.
+        self.handlers[model_id] = ModelHandle(spec)
+        logger.debug(f"Created actor: {self.handlers[model_id]}, type={type(self.handlers[model_id])}")
+        logger.debug(f"Models ({len(self.handlers)}): {self.handlers.keys()}")
+
+        return self.handlers[model_id]
+
+    def evict(self) -> ModelHandle:
+        """Evict a model from the manager (FIFO, LRU etc).
+
+        Returns:
+            ModelHandle: Model handle.
+        """
+        # Pop the oldest model
+        # TODO (spillai): Implement LRU policy
+        assert len(self.handlers) > 0, "No models to evict."
+        _, handle = self.handlers.popitem(last=False)
+        model_id = handle.spec.id
+        logger.debug(f"Deleting model: {model_id}")
+
+        # Explicitly kill the model handle (including all actors)
+        handle.kill()
+        logger.debug(f"Deleted model: {model_id}")
+        assert model_id not in self.handlers, f"Model should have been evicted: {model_id}"
+        return handle

--- a/nos/models/clip.py
+++ b/nos/models/clip.py
@@ -59,8 +59,20 @@ class CLIP:
     def encode_image(self, images: Union[Image.Image, np.ndarray, List[Image.Image], List[np.ndarray]]) -> np.ndarray:
         """Encode image into an embedding."""
         with torch.inference_mode():
-            if isinstance(images, (np.ndarray, Image.Image)):
+            if isinstance(images, np.ndarray):
+                if images.ndim == 3:
+                    images = [images]
+                elif images.ndim == 4:
+                    images = list(images)
+                else:
+                    raise ValueError(f"Invalid image shape: {images.shape}")
+            elif isinstance(images, Image.Image):
                 images = [images]
+            elif isinstance(images, list):
+                pass
+            else:
+                raise ValueError(f"Invalid images type: {type(images)}")
+
             inputs = self.processor(images=images, return_tensors="pt").to(self.device)
             image_features = self.model.get_image_features(**inputs)
             return image_features.cpu().numpy()

--- a/nos/proto/nos_service.proto
+++ b/nos/proto/nos_service.proto
@@ -56,6 +56,16 @@ message InferenceResponse {
   bytes response_bytes = 1;
 }
 
+// Register system shared memory request
+message GenericRequest {
+  bytes request_bytes = 1;
+}
+
+// Register system shared memory response
+message GenericResponse {
+  bytes response_bytes = 1;
+}
+
 
 // Ping / healthcheck response
 message PingResponse {
@@ -83,6 +93,12 @@ service InferenceService {
 
   // Run the inference request
   rpc Run(InferenceRequest) returns (InferenceResponse) {}
+
+  // Register shared memory
+  rpc RegisterSystemSharedMemory(GenericRequest) returns (GenericResponse) {}
+
+  // Unregister shared memory
+  rpc UnregisterSystemSharedMemory(GenericRequest) returns (GenericResponse) {}
 
   // Load model from Hugging Face Hub
   // TODO (spillai): To be implemented later (for power-users)

--- a/nos/server/runtime.py
+++ b/nos/server/runtime.py
@@ -38,18 +38,21 @@ class InferenceServiceRuntimeConfig:
     ports: Dict[int, int] = field(default_factory=lambda: {DEFAULT_GRPC_PORT: DEFAULT_GRPC_PORT})
     """Ports to expose."""
 
-    environment: Dict[str, str] = field(default_factory=lambda: {"NOS_LOGGING_LEVEL": LOGGING_LEVEL})
+    environment: Dict[str, str] = field(
+        default_factory=lambda: {
+            "NOS_LOGGING_LEVEL": LOGGING_LEVEL,
+            "NOS_SHM_ENABLED": 1,
+        }
+    )
     """Environment variables."""
 
     volumes: Dict[str, Dict[str, str]] = field(
         default_factory=lambda: {
-            str(Path.home() / ".nosd"): {"bind": "/app/.nos", "mode": "rw"},
+            str(Path.home() / ".nosd"): {"bind": "/app/.nos", "mode": "rw"},  # nos cache
+            "/dev/shm": {"bind": "/dev/shm", "mode": "rw"},  # shared-memory transport
         }
     )
     """Volumes to mount."""
-
-    shm_size: str = "4g"
-    """Size of /dev/shm."""
 
     detach: bool = True
     """Whether to run the container in detached mode."""

--- a/nos/server/service.py
+++ b/nos/server/service.py
@@ -1,22 +1,18 @@
-import os
-from collections import OrderedDict
-from dataclasses import dataclass, field
-from enum import Enum
-from typing import Any, Dict, List, Union
+from typing import Any, Dict
 
 import grpc
-import ray
 import rich.console
 import rich.status
-import torch
 from google.protobuf import empty_pb2
 
 from nos import hub
-from nos.common import ModelSpec, TaskType, dumps
+from nos.common import FunctionSignature, ModelSpec, TaskType, dumps, loads
+from nos.common.shm import NOS_SHM_ENABLED, SharedMemoryDataDict, SharedMemoryTransportManager
 from nos.constants import DEFAULT_GRPC_PORT  # noqa F401
 from nos.exceptions import ModelNotFoundError
 from nos.executors.ray import RayExecutor
 from nos.logging import logger
+from nos.managers import ModelHandle, ModelManager
 from nos.protoc import import_module
 from nos.version import __version__
 
@@ -25,189 +21,15 @@ nos_service_pb2 = import_module("nos_service_pb2")
 nos_service_pb2_grpc = import_module("nos_service_pb2_grpc")
 
 
-@dataclass
-class ModelHandle:
-    """Model handles for serving models.
-
-    Usage:
-        ```python
-        # Initialize a model handle
-        >> model_handle = ModelHandle(spec, num_replicas=1)
-
-        # Submit a task to the model handle
-        >> handler = model_handle.handle
-        >> response_ref = handler.submit(**model_inputs)
-
-        # Kill all actors
-        >> model_handle.kill()
-        ```
-    """
-
-    spec: ModelSpec
-    """Model specification."""
-    num_replicas: Union[int, str] = field(default=1)
-    """Number of replicas."""
-
-    _actors: List[Union[ray.remote, ray.actor.ActorHandle]] = field(init=False, default=None)
-    """Ray actor handle."""
-
-    def __post_init__(self):
-        """Initialize the actor handles."""
-        if self.num_replicas > 1:
-            raise NotImplementedError("Multiple replicas not yet supported.")
-        self._actors = [self.actor_from_spec(self.spec) for _ in range(self.num_replicas)]
-
-    @staticmethod
-    def actor_from_spec(spec: ModelSpec) -> Union[ray.remote, ray.actor.ActorHandle]:
-        """Get an actor handle from model specification."""
-        # TODO (spillai): Use the auto-tuned model spec to instantiate an
-        # actor the desired memory requirements. Fractional GPU amounts
-        # will need to be calculated from the target HW and model spec
-        # (i.e. 0.5 on A100 vs. T4 are different).
-        model_cls = spec.signature.func_or_cls
-        actor_options = {"num_gpus": 0.5 if torch.cuda.is_available() else 0}
-        logger.debug(f"Creating actor: {actor_options}, {model_cls}")
-        actor_cls = ray.remote(**actor_options)(model_cls)
-        return actor_cls.remote(*spec.signature.init_args, **spec.signature.init_kwargs)
-
-    def kill(self) -> None:
-        """Kill the actor handle."""
-        for actor_handle in self._actors:
-            ray.kill(actor_handle)
-
-    def remote(self, *args, **kwargs) -> ray.ObjectRef:
-        """Submit a task to the actor handle or pool."""
-        # Get the method function (i.e. `__call__`, or `predict`)
-        try:
-            actor_method_func = getattr(self.actor_handle, self.spec.signature.method_name)
-        except AttributeError as exc:
-            err = f"Failed to get method function: method={self.spec.signature.method_name}"
-            logger.error(f"{err}, exc={exc}")
-            raise Exception(err)
-
-        # Call the method function
-        response_ref: ray.ObjectRef = actor_method_func.remote(**kwargs)
-        return ray.get(response_ref)
-
-    @property
-    def actor_handle(self) -> Union[ray.remote, ray.actor.ActorHandle]:
-        """Get the actor handle."""
-        assert len(self._actors) == 1, "Only one actor handle is supported."
-        return self._actors[0]
-
-
-@dataclass(frozen=True)
-class ModelManager:
-    """Model manager for serving models with ray actors.
-
-    Features:
-      * Concurrency: Support fixed number of concurrent models,
-        running simultaneously with FIFO model eviction policies.
-      * Parallelism: Support multiple replicas of the same model.
-      * Optimal memory management: Model memory consumption
-        are automatically inferred from the model specification
-        and used to optimally bin-pack models on the GPU.
-      * Automatic garbage collection: Models are automatically
-        garbage collected when they are evicted from the manager.
-        Scaling models with the model manager should not result in OOM.
-
-    """
-
-    class EvictionPolicy(str, Enum):
-        FIFO = "FIFO"
-        LRU = "LRU"
-
-    policy: EvictionPolicy = EvictionPolicy.FIFO
-    """Eviction policy."""
-
-    max_concurrent_models: int = os.getenv("NOS_MAX_CONCURRENT_MODELS", 4)
-    """Maximum number of concurrent models."""
-
-    handlers: Dict[str, ModelHandle] = field(default_factory=OrderedDict)
-    """Model handles."""
-
-    def __post_init__(self):
-        if self.policy not in (self.EvictionPolicy.FIFO,):
-            raise NotImplementedError(f"Eviction policy not implemented: {self.policy}")
-
-    def __repr__(self) -> str:
-        """String representation of the model manager (memory consumption, models, in tabular format etc)."""
-        repr_str = f"ModelManager(policy={self.policy}, len(handlers)={len(self.handlers)})"
-        for idx, (model_id, model_handle) in enumerate(self.handlers.items()):
-            repr_str += f"\n\t{idx}: {model_id}, {model_handle}"
-        return repr_str
-
-    def get(self, model_spec: ModelSpec) -> ModelHandle:
-        """Get a model handle from the manager.
-
-        Create a new model handle if it does not exist,
-        else return an existing handle.
-
-        Args:
-            model_spec (ModelSpec): Model specification.
-        Returns:
-            ModelHandle: Model handle.
-        """
-        model_id: str = model_spec.id
-        if model_id not in self.handlers:
-            return self.add(model_spec)
-        else:
-            return self.handlers[model_id]
-
-    @logger.catch
-    def add(self, spec: ModelSpec) -> ModelHandle:
-        """Add a model to the manager.
-
-        Args:
-            spec (ModelSpec): Model specification.
-        Returns:
-            ModelHandle: Model handle.
-        """
-        # If the model already exists, raise an error
-        model_id = spec.id
-        if model_id in self.handlers:
-            raise ValueError(f"Model already exists: {model_id}")
-
-        # If the model handle is full, pop the oldest model
-        if len(self.handlers) >= self.max_concurrent_models:
-            _handle: ModelHandle = self.evict()
-            logger.info(f"Deleting oldest model: {_handle.spec.name}")
-
-        # Create the serve deployment from the model handle
-        logger.info(f"Initializing model with spec: {spec.name}")
-
-        # Note: Currently one model per (model-name, task) is supported.
-        self.handlers[model_id] = ModelHandle(spec)
-        logger.info(f"Created actor: {self.handlers[model_id]}, type={type(self.handlers[model_id])}")
-        logger.info(f"Models ({len(self.handlers)}): {self.handlers.keys()}")
-
-        return self.handlers[model_id]
-
-    @logger.catch
-    def evict(self) -> ModelHandle:
-        """Evict a model from the manager (FIFO, LRU etc)."""
-        # Pop the oldest model
-        # TODO (spillai): Implement LRU policy
-        assert len(self.handlers) > 0, "No models to evict."
-        _, handle = self.handlers.popitem(last=False)
-        model_id = handle.spec.id
-        logger.info(f"Deleting model: {model_id}")
-
-        # Explicitly kill the model handle (including all actors)
-        handle.kill()
-        logger.info(f"Deleted model: {model_id}")
-        assert model_id not in self.handlers, f"Model should have been evicted: {model_id}"
-        return handle
-
-
 class InferenceService:
     """Ray-executor based inference service.
 
     Parameters:
         model_manager (ModelManager): Model manager.
         executor (RayExecutor): Ray executor.
-
-    Note: To be used with the `InferenceServiceImpl` gRPC service.
+        shm_manager (SharedMemoryTransportManager): Shared memory transport manager.
+            Used to create shared memory buffers for inputs/outputs,
+            and to copy data to/from shared memory.
     """
 
     def __init__(self):
@@ -218,6 +40,10 @@ class InferenceService:
         except Exception as e:
             logger.info(f"Failed to initialize executor: {e}")
             raise RuntimeError(f"Failed to initialize executor: {e}")
+        if NOS_SHM_ENABLED:
+            self.shm_manager = SharedMemoryTransportManager()
+        else:
+            self.shm_manager = None
 
     @logger.catch
     def execute(self, model_name: str, task: TaskType = None, inputs: Dict[str, Any] = None) -> Dict[str, Any]:
@@ -238,7 +64,8 @@ class InferenceService:
             raise ModelNotFoundError(f"Failed to load model spec: {model_name}, {e}")
 
         # TODO (spillai): Validate/Decode the inputs
-        model_inputs = model_spec.signature._decode_inputs(inputs)
+        model_inputs = FunctionSignature.validate(inputs, model_spec.signature.inputs)
+        model_inputs = SharedMemoryDataDict.decode(model_inputs)
 
         # Initialize the model (if not already initialized)
         # This call should also evict models and garbage collect if
@@ -246,11 +73,14 @@ class InferenceService:
         model_handle: ModelHandle = self.model_manager.get(model_spec)
 
         # Get the model handle and call it remotely (with model spec, actor handle)
-        response = model_handle.remote(**model_inputs)
+        response: Dict[str, Any] = model_handle.remote(**model_inputs)
 
         # If the response is a single value, wrap it in a dict with the appropriate key
         if len(model_spec.signature.outputs) == 1:
-            response = {k: response for k in model_spec.signature.outputs}
+            response: Dict[str, Any] = {k: response for k in model_spec.signature.outputs}
+
+        # Encode the response
+        response = SharedMemoryDataDict.encode(response)
 
         return response
 
@@ -268,19 +98,16 @@ class InferenceServiceImpl(nos_service_pb2_grpc.InferenceServiceServicer, Infere
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    @logger.catch
     def Ping(self, request: empty_pb2.Empty, context: grpc.ServicerContext) -> nos_service_pb2.PingResponse:
         """Health check."""
         return nos_service_pb2.PingResponse(status="ok")
 
-    @logger.catch
     def GetServiceInfo(
         self, request: empty_pb2.Empty, context: grpc.ServicerContext
     ) -> nos_service_pb2.ServiceInfoResponse:
         """Get information on the service."""
         return nos_service_pb2.ServiceInfoResponse(version=__version__)
 
-    @logger.catch
     def ListModels(self, request: empty_pb2.Empty, context: grpc.ServicerContext) -> nos_service_pb2.ModelListResponse:
         """List all models."""
         response = nos_service_pb2.ModelListResponse()
@@ -288,7 +115,6 @@ class InferenceServiceImpl(nos_service_pb2_grpc.InferenceServiceServicer, Infere
             response.models.append(nos_service_pb2.ModelInfo(name=spec.name, task=spec.task.value))
         return response
 
-    @logger.catch
     def GetModelInfo(
         self, request: nos_service_pb2.ModelInfoRequest, context: grpc.ServicerContext
     ) -> nos_service_pb2.ModelInfoResponse:
@@ -297,10 +123,46 @@ class InferenceServiceImpl(nos_service_pb2_grpc.InferenceServiceServicer, Infere
             model_info = request.request
             spec: ModelSpec = hub.load_spec(model_info.name, task=TaskType(model_info.task))
         except KeyError as e:
+            logger.error(f"Model not found: {e}")
             context.abort(context, grpc.StatusCode.NOT_FOUND, str(e))
         return spec._to_proto(public=True)
 
-    @logger.catch
+    def RegisterSystemSharedMemory(
+        self, request: nos_service_pb2.GenericRequest, context: grpc.ServicerContext
+    ) -> nos_service_pb2.GenericResponse:
+        """Register system shared memory with a dry-run inference request."""
+        if not NOS_SHM_ENABLED:
+            context.abort(context, grpc.StatusCode.UNIMPLEMENTED, "Shared memory not enabled.")
+
+        metadata = dict(context.invocation_metadata())
+        client_id = metadata.get("client_id", None)
+        spec_id = metadata.get("spec_id", None)
+        logger.debug(f"Registering system shared memory for client_id={client_id}, spec_id={spec_id}")
+        try:
+            shm_map = self.shm_manager.create(loads(request.request_bytes), namespace=f"{client_id}/{spec_id}")
+            return nos_service_pb2.GenericResponse(response_bytes=dumps(shm_map))
+        except Exception as e:
+            logger.error(f"Failed to register system shared memory: {e}")
+            context.abort(context, grpc.StatusCode.INTERNAL, str(e))
+
+    def UnregisterSystemSharedMemory(
+        self, request: nos_service_pb2.GenericRequest, context: grpc.ServicerContext
+    ) -> nos_service_pb2.GenericResponse:
+        """Unregister system shared memory."""
+        if not NOS_SHM_ENABLED:
+            context.abort(context, grpc.StatusCode.UNIMPLEMENTED, "Shared memory not enabled.")
+
+        metadata = dict(context.invocation_metadata())
+        client_id = metadata.get("client_id", None)
+        spec_id = metadata.get("spec_id", None)
+        logger.debug(f"Unregistering system shared memory for client_id={client_id}, spec_id={spec_id}")
+        try:
+            self.shm_manager.cleanup(namespace=f"{client_id}/{spec_id}")
+        except Exception as e:
+            logger.error(f"Failed to unregister system shared memory: {e}")
+            context.abort(context, grpc.StatusCode.INTERNAL, str(e))
+        return nos_service_pb2.GenericResponse()
+
     def Run(
         self, request: nos_service_pb2.InferenceRequest, context: grpc.ServicerContext
     ) -> nos_service_pb2.InferenceResponse:
@@ -320,9 +182,9 @@ class InferenceServiceImpl(nos_service_pb2_grpc.InferenceServiceServicer, Infere
             logger.debug(f"Executing request: {model_request.task}, {model_request.name}")
             response = self.execute(model_request.name, task=TaskType(model_request.task), inputs=request.inputs)
             return nos_service_pb2.InferenceResponse(response_bytes=dumps(response))
-        except Exception as exc:
+        except Exception as e:
             logger.error(f"Failed to execute request: {model_request.task}, {model_request.name}, {request.inputs}")
-            context.abort(context, grpc.StatusCode.INTERNAL, str(exc))
+            context.abort(context, grpc.StatusCode.INTERNAL, str(e))
 
 
 def serve(address: str = f"[::]:{DEFAULT_GRPC_PORT}", max_workers: int = 1) -> None:

--- a/nos/test/conftest.py
+++ b/nos/test/conftest.py
@@ -30,7 +30,7 @@ def ray_executor():
 
 
 @pytest.fixture(scope="session")
-def grpc_server():
+def grpc_server(ray_executor):
     """Test gRPC server (Port: 50052)."""
     from loguru import logger
 
@@ -101,7 +101,7 @@ def grpc_server_docker_runtime_cpu():
     assert status is not None and status == "running"
 
     # Yield the running container
-    yield container
+    yield runtime
 
     # Tear down
     try:
@@ -137,7 +137,7 @@ def grpc_server_docker_runtime_gpu():
     assert status is not None and status == "running"
 
     # Yield the running container
-    yield container
+    yield runtime
 
     # Tear down
     try:

--- a/tests/client/grpc/conftest.py
+++ b/tests/client/grpc/conftest.py
@@ -2,15 +2,29 @@ import pytest
 from loguru import logger
 
 from nos.test.conftest import (  # noqa: F401, E402  # noqa: F401, E402
+    grpc_client,
     grpc_client_cpu,
     grpc_client_gpu,
+    grpc_server,
     grpc_server_docker_runtime_cpu,
     grpc_server_docker_runtime_gpu,
+    ray_executor,
 )
 
 
 @pytest.fixture(scope="session")
-def grpc_client_with_cpu_backend(grpc_server_docker_runtime_cpu, grpc_client_cpu):  # noqa: F811
+def grpc_client_with_server(grpc_server, grpc_client):  # noqa: F811
+    """Test gRPC client with local gRPC server (Port: 50052)."""
+    # Wait for server to start
+    grpc_client.WaitForServer(timeout=180, retry_interval=5)
+    logger.info("Server started!")
+
+    # Yield the gRPC client once the server is up and initialized
+    yield grpc_client
+
+
+@pytest.fixture(scope="session")
+def grpc_client_with_docker_runtime_server_cpu(grpc_server_docker_runtime_cpu, grpc_client_cpu):  # noqa: F811
     """Test gRPC client with initialized CPU docker runtime (Port: 50053)."""
     # Wait for server to start
     grpc_client_cpu.WaitForServer(timeout=180, retry_interval=5)
@@ -21,7 +35,7 @@ def grpc_client_with_cpu_backend(grpc_server_docker_runtime_cpu, grpc_client_cpu
 
 
 @pytest.fixture(scope="session")
-def grpc_client_with_gpu_backend(grpc_server_docker_runtime_gpu, grpc_client_gpu):  # noqa: F811
+def grpc_client_with_docker_runtime_server_gpu(grpc_server_docker_runtime_gpu, grpc_client_gpu):  # noqa: F811
     """Test gRPC client with initialized CPU docker runtime (Port: 50054)."""
     # Wait for server to start
     grpc_client_gpu.WaitForServer(timeout=180, retry_interval=5)

--- a/tests/client/grpc/test_grpc_client_e2e.py
+++ b/tests/client/grpc/test_grpc_client_e2e.py
@@ -11,23 +11,21 @@ import pytest
 from PIL import Image
 from tqdm import tqdm
 
-
-pytestmark = pytest.mark.client
-
 from nos.common import ModelSpec, TaskType  # noqa: E402
 from nos.test.utils import NOS_TEST_IMAGE  # noqa: E402
 
 
-@pytest.mark.skip(reason="This test is not ready yet.")
-@pytest.mark.client
-def test_e2e_grpc_client_and_gpu_server(grpc_client_with_gpu_backend):  # noqa: F811
+pytestmark = pytest.mark.client
+
+
+def test_e2e_grpc_client_and_gpu_server(grpc_server_docker_runtime_gpu):  # noqa: F811
     """Test the gRPC client with GPU docker runtime initialized.
 
     This test spins up a gRPC inference server within a
     GPU docker-runtime environment initialized and then issues
     requests to it using the gRPC client.
     """
-    client = grpc_client_with_gpu_backend
+    client = grpc_server_docker_runtime_gpu
 
     img = Image.open(NOS_TEST_IMAGE)
     img = np.array(img)
@@ -82,7 +80,7 @@ def test_e2e_grpc_client_and_gpu_server(grpc_client_with_gpu_backend):  # noqa: 
     assert model is not None
     assert model.GetModelInfo() is not None
     for _ in tqdm(range(1), desc=f"Bench [task={task}, model_name={model_name}]"):
-        response = model(img=img)
+        response = model(images=[img])
         assert isinstance(response, dict)
         assert "embedding" in response
 
@@ -108,15 +106,14 @@ def test_e2e_grpc_client_and_gpu_server(grpc_client_with_gpu_backend):  # noqa: 
         assert "images" in response
 
 
-@pytest.mark.client
-def test_e2e_grpc_client_and_cpu_server(grpc_client_with_cpu_backend):  # noqa: F811
+def test_e2e_grpc_client_and_cpu_server(grpc_client_with_docker_runtime_server_cpu):  # noqa: F811
     """Test the gRPC client with CPU docker runtime initialized.
 
     This test spins up a gRPC inference server within a
     CPU docker-runtime environment initialized and then issues
     requests to it using the gRPC client.
     """
-    client = grpc_client_with_cpu_backend
+    client = grpc_client_with_docker_runtime_server_cpu
 
     img = Image.open(NOS_TEST_IMAGE)
     img = np.array(img)

--- a/tests/common/io/video/test_opencv.py
+++ b/tests/common/io/video/test_opencv.py
@@ -13,7 +13,6 @@ VIDEO_FILES = [NOS_TEST_VIDEO]
 def test_video(filename):
     from itertools import islice
 
-    logger.info(f"Testing video {filename}")
     video = VideoFile(filename)
 
     # Test len()

--- a/tests/common/test_common_types.py
+++ b/tests/common/test_common_types.py
@@ -20,6 +20,9 @@ def test_common_types():
     import numpy as np
     from PIL import Image
 
+    assert TensorSpec(shape=(None, None, 3), dtype="float32").nbytes is None
+    assert TensorSpec(shape=(480, 640, 3), dtype="float32").nbytes == 480 * 640 * 3 * 4
+
     # Tensor types with TensorSpec metadata
     TensorT[np.ndarray]  # without metadata (just a dyanmic tensor)
     TensorT[np.ndarray, TensorSpec(shape=(480, 640, 3), dtype="float32")]

--- a/tests/managers/test_model_manager.py
+++ b/tests/managers/test_model_manager.py
@@ -1,0 +1,115 @@
+import numpy as np
+import pytest
+from loguru import logger
+
+from nos import hub
+from nos.managers import ModelHandle, ModelManager
+from nos.test.conftest import ray_executor  # noqa: F401
+
+
+@pytest.fixture
+def manager(ray_executor):  # noqa: F811
+    manager = ModelManager()
+    assert manager is not None
+
+    yield manager
+
+
+def test_model_manager(manager):  # noqa: F811
+    # Test adding several models back to back with the same manager.
+    # This should not raise any OOM errors as models are evicted
+    # from the manager's cache.
+    for idx, spec in enumerate(hub.list()):
+        # Note: `manager.get()` is a wrapper around `manager.add()`
+        # and creates a single replica of the model.
+        handler: ModelHandle = manager.get(spec)
+        assert handler is not None
+        assert isinstance(handler, ModelHandle)
+
+        logger.debug(">" * 80)
+        logger.debug(f"idx: {idx}")
+        logger.debug(f"Model manager: {manager}, spec: {spec}")
+
+    # Check if the model manager contains the model.
+    assert spec in manager
+
+
+def test_model_manager_errors(manager):
+    # Get model specs
+    spec = None
+    for _, _spec in enumerate(hub.list()):
+        spec = _spec
+        break
+
+    # Re-adding the same model twice should raise a `ValueError`.
+    manager.add(spec)
+    assert spec in manager
+    with pytest.raises(ValueError):
+        manager.add(spec)
+
+    # Creating a model with num_replicas > 1 should raise a `NotImplementedError`.
+    with pytest.raises(NotImplementedError):
+        ModelHandle(spec, num_replicas=2)
+
+    # Creating a model with an invalid eviction policy should raise a `NotImplementedError`.
+    with pytest.raises(NotImplementedError):
+        ModelManager(policy=ModelManager.EvictionPolicy.LRU)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "openai/clip-vit-base-patch32",
+    ],
+)
+@pytest.mark.parametrize("scale", [1, 8])
+def test_model_manager_inference(model_name, scale, manager):  # noqa: F811
+    """Benchmark the model manager with a single model."""
+    import time
+
+    from PIL import Image
+    from tqdm import tqdm
+
+    from nos.common import TaskType
+    from nos.test.utils import NOS_TEST_IMAGE
+
+    img = Image.open(NOS_TEST_IMAGE)
+    W, H = 224, 224
+    img = img.resize((W * scale, H * scale))
+    img = np.asarray(img)
+
+    # Load a model spec
+    task = TaskType.IMAGE_EMBEDDING
+    spec = hub.load_spec(model_name, task=task)
+
+    # Add the model to the manager (or via `manager.add()`)
+    handle: ModelHandle = manager.get(spec)
+    assert handle is not None
+
+    # Warmup
+    for _ in tqdm(range(10), desc=f"Warmup model={model_name}, B=1", total=0):
+        images = [img]
+        result = handle.remote(images=images)
+        assert result is not None
+        assert isinstance(result, np.ndarray)
+
+    # Benchmark (10s)
+    for b in range(0, 8):
+        B = 2**b
+        images = [img for _ in range(B)]
+        st = time.time()
+        for _ in tqdm(
+            range(100_000),
+            desc=f"Benchmark model={model_name}, task={task} [B={B}, shape={img.shape}]",
+            unit="images",
+            unit_scale=B,
+            total=0,
+        ):
+            embedding = handle.remote(images=images)
+            assert embedding is not None
+            assert isinstance(embedding, np.ndarray)
+            N, _ = embedding.shape
+            assert N == B
+            if time.time() - st > 10.0:
+                break

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+from loguru import logger
+
+from nos.test.conftest import (  # noqa: F401, E402  # noqa: F401, E402
+    grpc_client,
+    grpc_server,
+    ray_executor,
+)
+
+
+@pytest.fixture(scope="session")
+def grpc_client_with_server(grpc_server, grpc_client):  # noqa: F811
+    """Test gRPC client with local gRPC server (Port: 50052)."""
+    # Wait for server to start
+    grpc_client.WaitForServer(timeout=180, retry_interval=5)
+    logger.info("Server started!")
+
+    # Yield the gRPC client once the server is up and initialized
+    yield grpc_client


### PR DESCRIPTION
## Summary

This PR provides an initial implementation of the shared memory transport for numpy arrays. We introduce `SharedMemoryNumpyArray` as a temporary structure for passing numpy arrays between processes. This structure is a wrapper around `numpy.ndarray` that can be shared via shared memory.

 - Added tests for model manager in `tests/managers/test_model_manager.py`
 - Added tests for shared memory transport in `tests/service/test_inference_service.py`

## Related issues

#136 #69 

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
