### PR TITLE
Fixed FasterRCNN scores passthrough

### DIFF
--- a/nos/models/faster_rcnn.py
+++ b/nos/models/faster_rcnn.py
@@ -54,7 +54,7 @@ class FasterRCNN:
             images = images.to(self.device)
             predictions = self.model(images)
             return {
-                "scores": [pred["boxes"].cpu().numpy() for pred in predictions],
+                "scores": [pred["scores"].cpu().numpy() for pred in predictions],
                 "labels": [pred["labels"].cpu().numpy() for pred in predictions],
                 "bboxes": [pred["boxes"].cpu().numpy() for pred in predictions],
             }

--- a/tests/models/test_faster_rcnn.py
+++ b/tests/models/test_faster_rcnn.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 from PIL import Image
 
@@ -14,12 +15,15 @@ def model():
 
 def _test_predict(_model):
     img = Image.open(NOS_TEST_IMAGE)
+    W, H = img.size
     predictions = _model.predict([img, img])
     assert predictions is not None
 
     assert predictions["scores"] is not None
     assert isinstance(predictions["scores"], list)
     assert len(predictions["scores"]) == 2
+    for scores in predictions["scores"]:
+        assert np.min(scores) >= 0.0 and np.max(scores) <= 1.0
 
     assert predictions["labels"] is not None
     assert isinstance(predictions["labels"], list)
@@ -28,6 +32,9 @@ def _test_predict(_model):
     assert predictions["bboxes"] is not None
     assert isinstance(predictions["bboxes"], list)
     assert len(predictions["bboxes"]) == 2
+    for bbox in predictions["bboxes"]:
+        assert (bbox[:, 0] >= 0).all() and (bbox[:, 0] <= W).all()
+        assert (bbox[:, 1] >= 0).all() and (bbox[:, 1] <= H).all()
 
 
 def test_fasterrcnn_predict(model):


### PR DESCRIPTION
## Summary
FasterRCNN scores were not being propagated correctly. 

 - added relevant tests for bbox and score values

<!-- Thank you for your contribution! Please review https://github.com/autonomi-ai/nos/blob/main/docs/CONTRIBUTING.md before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
