### PR TITLE
[hub] Add MIDAS monodepth model

### DIFF
--- a/nos/common/tasks.py
+++ b/nos/common/tasks.py
@@ -8,6 +8,8 @@ class TaskType(Enum):
     """2D object detection."""
     IMAGE_SEGMENTATION_2D = "image_segmentation_2d"
     """2D image segmentation."""
+    DEPTH_ESTIMATION_2D = "depth_estimation_2d"
+    """2D depth estimation."""
 
     IMAGE_CLASSIFICATION = "image_classification"
     """Image classification."""

--- a/nos/models/__init__.py
+++ b/nos/models/__init__.py
@@ -11,6 +11,7 @@ from nos.common.types import Batch, ImageT
 from ._noop import NoOp  # noqa: F401
 from .clip import CLIP  # noqa: F401
 from .faster_rcnn import FasterRCNN  # noqa: F401
+from .monodepth import MonoDepth  # noqa: F401
 from .openmmlab.mmdetection.mmdetection import MMDetection  # noqa: F401
 from .sam import SAM
 from .stable_diffusion import StableDiffusion  # noqa: F401

--- a/nos/models/monodepth.py
+++ b/nos/models/monodepth.py
@@ -1,0 +1,83 @@
+from dataclasses import dataclass
+from typing import List, Union
+
+import numpy as np
+import torch
+from PIL import Image
+
+from nos import hub
+from nos.common import ImageSpec, TaskType
+from nos.common.io import prepare_images
+from nos.common.types import Batch, ImageT, TensorT
+from nos.hub import TorchHubConfig
+
+
+@dataclass(frozen=True)
+class DepthConfig(TorchHubConfig):
+    """Depth model configuration."""
+
+    def get_transforms(self):
+        """Get model-specific transforms for pre-processing."""
+        if self.model_name.startswith("DPT_"):
+            return torch.hub.load(self.repo, "transforms").dpt_transform
+        return torch.hub.load(self.repo, "transforms").small_transform
+
+
+class MonoDepth:
+    """Monodepth models for depth understanding."""
+
+    configs = {
+        "isl-org/MiDaS_small": DepthConfig(
+            repo="isl-org/MiDaS",
+            model_name="MiDaS_small",
+        ),
+        "isl-org/MiDaS": DepthConfig(
+            repo="isl-org/MiDaS",
+            model_name="MiDaS",
+        ),
+    }
+
+    def __init__(self, model_name: str = "isl-org/MiDaS_small"):
+        """Initialize the model."""
+        try:
+            self.cfg = MonoDepth.configs[model_name]
+        except KeyError:
+            raise ValueError(f"Invalid model_name: {model_name}, available models: {MonoDepth.configs.keys()}")
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.transforms = self.cfg.get_transforms()
+        self.model = torch.hub.load(self.cfg.repo, self.cfg.model_name, pretrained=True).to(self.device)
+        self.model.eval()
+
+    def __call__(self, images: Union[Image.Image, np.ndarray, List[Image.Image], List[np.ndarray]]) -> np.ndarray:
+        """Predict depth from image."""
+        images = prepare_images(images)
+        H, W = images[0].shape[:2]
+        with torch.inference_mode():
+            input_batch = torch.cat([self.transforms(image) for image in images]).to(self.device)
+            prediction = self.model(input_batch)  # (B, dH, dW)
+            prediction = torch.nn.functional.interpolate(
+                prediction.unsqueeze(1),
+                size=(H, W),
+                mode="bicubic",
+                align_corners=False,
+            ).squeeze()
+            return prediction.cpu().numpy()
+
+
+for model_name in MonoDepth.configs:
+    hub.register(
+        model_name,
+        TaskType.DEPTH_ESTIMATION_2D,
+        MonoDepth,
+        init_args=(model_name,),
+        method_name="__call__",
+        inputs={
+            "images": Union[
+                Batch[ImageT[Image.Image, ImageSpec(shape=(480, 640, 3), dtype="uint8")], 8],
+                Batch[ImageT[Image.Image, ImageSpec(shape=(960, 1280, 3), dtype="uint8")], 4],
+            ]
+        },
+        outputs={
+            "depths": Batch[TensorT[np.ndarray, ImageSpec(shape=(None, None, 1), dtype="float32")]],
+        },
+    )

--- a/requirements/requirements.server.txt
+++ b/requirements/requirements.server.txt
@@ -4,5 +4,7 @@ huggingface_hub
 memray
 pyarrow>=12.0.0
 ray[serve]==2.5.0
+safetensors>=0.3.0
 tabulate
+timm>=0.9.2
 transformers>=4.29.2

--- a/tests/hub/test_hub_inference.py
+++ b/tests/hub/test_hub_inference.py
@@ -11,7 +11,13 @@ def hub_image_models():
     return [
         spec
         for spec in models
-        if spec.task in (TaskType.IMAGE_EMBEDDING, TaskType.OBJECT_DETECTION_2D) and not spec.name.endswith("trt")
+        if spec.task
+        in (
+            TaskType.IMAGE_EMBEDDING,
+            TaskType.OBJECT_DETECTION_2D,
+            TaskType.DEPTH_ESTIMATION_2D,
+        )
+        and not spec.name.endswith("-trt")
     ]
 
 
@@ -39,6 +45,7 @@ def test_hub_batched_image_inference():
 
     for spec in hub_image_models():
         logger.debug(f"Testing model [name={spec.name}, task={spec.task}]")
+
         # Run inference for each model (image-based models only)
         model = hub.load(spec.name, spec.task)
         predict = getattr(model, spec.signature.method_name)

--- a/tests/models/test_monodepth.py
+++ b/tests/models/test_monodepth.py
@@ -1,0 +1,80 @@
+"""Tests for monocular depth estimation models.
+
+Benchmark results (2080 Ti):
+
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+(640, 480)
+[isl-org/MiDaS_small]: 11.23 ms / step
+[isl-org/MiDaS]: 19.05 ms / step
+
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+(1280, 960)
+[isl-org/MiDaS_small]: 16.41 ms / step
+[isl-org/MiDaS]: 24.54 ms / step
+"""
+
+import numpy as np
+import pytest
+from loguru import logger
+from PIL import Image
+
+from nos import hub
+from nos.common import TaskType
+from nos.models import MonoDepth
+from nos.test.benchmark import run_benchmark
+from nos.test.utils import NOS_TEST_IMAGE, PyTestGroup, skip_if_no_torch_cuda
+
+
+MODELS = list(MonoDepth.configs.keys())
+
+
+def _test_predict(_model):
+    img = Image.open(NOS_TEST_IMAGE)
+    W, H = img.size
+    predictions = _model([img, img])
+    assert predictions is not None
+    assert isinstance(predictions, np.ndarray)
+    assert len(predictions) == 2
+    for pred in predictions:
+        assert pred.shape[-2:] == (H, W)
+
+
+@skip_if_no_torch_cuda
+@pytest.mark.parametrize("model_name", MODELS[:1])
+def test_monodepth_predict_one(model_name):
+    """ "Load/infer first depth estimation model."""
+    logger.debug(f"Testing model: {model_name}")
+    spec = hub.load_spec(model_name, task=TaskType.DEPTH_ESTIMATION_2D)
+    model = hub.load(spec.name, task=spec.task)
+    _test_predict(model)
+
+
+@skip_if_no_torch_cuda
+@pytest.mark.benchmark(group=PyTestGroup.HUB)
+@pytest.mark.parametrize("model_name", MODELS)
+def test_monodepth_predict_all(model_name):
+    """ "Benchmark load/infer all depth estimation models."""
+    logger.debug(f"Testing model: {model_name}")
+    spec = hub.load_spec(model_name, task=TaskType.DEPTH_ESTIMATION_2D)
+    model = hub.load(spec.name, task=spec.task)
+    _test_predict(model)
+
+
+@skip_if_no_torch_cuda
+@pytest.mark.benchmark(group=PyTestGroup.MODEL_BENCHMARK)
+@pytest.mark.parametrize("model_name", MODELS)
+@pytest.mark.parametrize("img_size", [(640, 480), (1280, 960)])
+def test_monodepth_predict_benchmark(model_name, img_size):
+    """ "Benchmark inference for all depth estimation models."""
+
+    img = Image.open(NOS_TEST_IMAGE)
+    img = img.resize(img_size)
+
+    logger.debug(f"Benchmarking model: {model_name}, img_size: {img_size}")
+    spec = hub.load_spec(model_name, task=TaskType.DEPTH_ESTIMATION_2D)
+    model = hub.load(spec.name, task=spec.task)
+    time_ms = run_benchmark(
+        lambda: model(img),
+        num_iters=100,
+    )
+    logger.debug(f"[{model_name}]: {time_ms:.2f} ms / step")

--- a/tests/models/test_object_detection.py
+++ b/tests/models/test_object_detection.py
@@ -118,7 +118,8 @@ def test_object_detection_predict_one(model_name, img_size):
 @skip_if_no_torch_cuda
 @pytest.mark.benchmark(group=PyTestGroup.HUB)
 @pytest.mark.parametrize("model_name", MODELS)
-def test_object_detection_predict_variants(model_name):
+def test_object_detection_predict_all(model_name):
+    """ "Benchmark load/infer all object detection models."""
     logger.debug(f"Testing model: {model_name}")
     spec = hub.load_spec(model_name, task=TaskType.OBJECT_DETECTION_2D)
     model = hub.load(spec.name, task=spec.task)
@@ -136,7 +137,7 @@ def test_object_detection_predict_variants(model_name):
     ],
 )
 def test_object_detection_predict_benchmark(model_name, img_size):
-    """object detection models."""
+    """ "Benchmark inference for all object detection models."""
 
     img = Image.open(NOS_TEST_IMAGE)
     img = img.resize(img_size)


### PR DESCRIPTION
## Summary
- added tests for monodepth model
- new task definition for depth estimation `DEPTH_ESTIMATION_2D`

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
