### PR TITLE
Fix allowable image resolutions forr yolox and faster rcnn

### DIFF
--- a/nos/models/faster_rcnn.py
+++ b/nos/models/faster_rcnn.py
@@ -75,8 +75,7 @@ hub.register(
     inputs={
         "images": Union[
             Batch[ImageT[Image.Image, ImageSpec(shape=(480, 640, 3), dtype="uint8")], 8],
-            Batch[ImageT[Image.Image, ImageSpec(shape=(960, 1280, 3), dtype="uint8")], 4],
-            Batch[ImageT[Image.Image, ImageSpec(shape=(1080, 1920, 3), dtype="uint8")], 1],
+            Batch[ImageT[Image.Image, ImageSpec(shape=(960, 1280, 3), dtype="uint8")], 1],
         ]
     },
     outputs={

--- a/nos/models/yolox.py
+++ b/nos/models/yolox.py
@@ -184,7 +184,7 @@ for model_name in YOLOX.configs:
         inputs={
             "images": Union[
                 Batch[ImageT[Image.Image, ImageSpec(shape=(480, 640, 3), dtype="uint8")], 8],
-                Batch[ImageT[Image.Image, ImageSpec(shape=(960, 1280, 3), dtype="uint8")], 4],
+                Batch[ImageT[Image.Image, ImageSpec(shape=(960, 1280, 3), dtype="uint8")], 1],
             ]
         },
         outputs={


### PR DESCRIPTION
## Summary
- Relax bounding box coords in tests
- Add tests for all unique model families

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [x] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
