### PR TITLE
Update pyproject.toml to exclude build, experimental etc.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,20 @@ dependency_links = [
     "https://download.pytorch.org/whl/cu117",
 ]
 
+[tool.setuptools]
+include-package-data = false
+
 [tool.setuptools.packages.find]
 include = ["nos*","scripts*"]
 exclude = [
-    "nos*experimental",
+    "build",
+    "conda",
+    "dist",
+    "docs",
+    "makefiles",
+    "requirements",
+    "tests",
+    "nos*experimental*",
 ]
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
We've been inadvertently including build, experimental in Pypi releases due to malformed pyproject excludes.

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
