### PR TITLE
Set resource limits for nos container to avoid cached raylets

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -17,5 +17,8 @@ services:
       - NOS_LOGGING_LEVEL=DEBUG
     volumes:
       - ~/.nosd:/app/.nos
-      - /tmp:/tmp
-    shm_size: 4G
+    deploy:
+      resources:
+        limits:
+          cpus: "6"
+          memory: 6G

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -17,9 +17,11 @@ services:
       - NOS_LOGGING_LEVEL=DEBUG
     volumes:
       - ~/.nosd:/app/.nos
-    shm_size: 4G
     deploy:
       resources:
         reservations:
           devices:
             - capabilities: [gpu]
+        limits:
+          cpus: "6"
+          memory: 6G

--- a/examples/quickstart/docker-compose.quickstart.yml
+++ b/examples/quickstart/docker-compose.quickstart.yml
@@ -11,4 +11,8 @@ services:
       - NOS_LOGGING_LEVEL=ERROR
     volumes:
       - ~/.nosd:/app/.nos
-    shm_size: 4G
+    deploy:
+      resources:
+        limits:
+          cpus: "6"
+          memory: 6G

--- a/nos/client/grpc.py
+++ b/nos/client/grpc.py
@@ -208,7 +208,7 @@ class InferenceClient:
         except grpc.RpcError as e:
             raise NosClientException(f"Failed to get model info ({e})")
 
-    @lru_cache(maxsize=32)  # noqa: B019
+    @lru_cache(maxsize=8)  # noqa: B019
     def Module(self, task: TaskType, model_name: str) -> "InferenceModule":
         """Instantiate a model module.
 
@@ -220,7 +220,7 @@ class InferenceClient:
         """
         return InferenceModule(task, model_name, self)
 
-    @lru_cache(maxsize=32)  # noqa: B019
+    @lru_cache(maxsize=8)  # noqa: B019
     def ModuleFromSpec(self, spec: ModelSpec) -> "InferenceModule":
         """Instantiate a model module from a model spec.
 

--- a/nos/executors/ray.py
+++ b/nos/executors/ray.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 NOS_RAY_NS = os.getenv("NOS_RAY_NS", "nos-dev")
 NOS_RAY_RUNTIME_ENV = os.getenv("NOS_RAY_ENV", None)
+NOS_RAY_OBJECT_STORE_MEMORY = int(os.getenv("NOS_RAY_OBJECT_STORE_MEMORY", 4 * 1024 * 1024 * 1024))  # 4GB
 
 
 @dataclass
@@ -140,6 +141,7 @@ class RayExecutor:
                     address="local",
                     namespace=self.spec.namespace,
                     runtime_env=self.spec.runtime_env,
+                    object_store_memory=NOS_RAY_OBJECT_STORE_MEMORY,
                     ignore_reinit_error=False,
                     include_dashboard=False,
                     configure_logging=True,

--- a/nos/server/runtime.py
+++ b/nos/server/runtime.py
@@ -57,7 +57,12 @@ class InferenceServiceRuntimeConfig:
     gpu: bool = False
     """Whether to start the container with GPU support."""
 
-    kwargs: Dict[str, Any] = field(default_factory=dict)
+    kwargs: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "nano_cpus": int(6e9),
+            "mem_limit": "6g",
+        }
+    )
     """Additional keyword-arguments to pass to `DockerRuntime.start`."""
 
 


### PR DESCRIPTION
## Summary

 - Ray seems to allocate and cache raylets based on the container's CPU limits. This means that we need to explicitly set resource limits on the nos container to avoid having Ray unncessarily cache raylets without actually using them.

  - updated resource limits for cpu/gpu docker compose files and the defaults for `InferenceServiceRuntime`.

  - also added the ability to manually set `NOS_RAY_OBJECT_STORE_MEMORY` (currently `4GB`) as an environment variable for the nos container.

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
