### PR TITLE
New makefile targets for benchmark tests (CPU/GPU) w/ docker variants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,9 @@ help:
 	@echo "  test-cpu            Basic CPU testing"
 	@echo "  test-client         Basic client-side testing"
 	@echo "  test-server         Server-side testing (all GPUs)"
-	@echo "  test-benchmark      Testing with benchmarks (all GPUs)"
+	@echo "  test-cpu-benchmark  Testing with benchmarks (CPUs)"
+	@echo "  test-gpu-benchmark  Testing with benchmarks (GPUs)"
+	@echo "  test-all			 All tests including CPU, GPU, client, and server
 	@echo "  dist                Builds source and wheel package"
 	@echo ""
 
@@ -99,13 +101,17 @@ test-client: docker-build-cpu docker-build-gpu ## Basic client-side testing
 	CUDA_VISIBLE_DEVICES="" \
 	pytest -sv tests/client -m "client"
 
-test-benchmark: ## Testing with benchmarks (all GPUs)
+test-cpu-benchmark: ## Testing with benchmarks (no GPUs)
+	CUDA_VISIBLE_DEVICES="" \
+	pytest -sv tests -m "benchmark"
+
+test-gpu-benchmark: ## Testing with benchmarks (all GPUs)
 	pytest -sv tests -m "benchmark"
 
 test-server: ## Server-side testing (all GPUs)
 	pytest -sv tests -m "server"
 
-test-all:  ## ALl tests including CPU, GPU, client, and server
+test-all:  ## All tests including CPU, GPU, client, and server
 	make test-cpu test-gpu test-client test-server
 
 dist: clean ## builds source and wheel package

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,6 +2,8 @@ version: "3.8"
 
 x-nos-common:
   &nos-common-test
+  volumes:
+    - ~/.nosd:/app/.nos
   environment:
     - NOS_LOGGING_LEVEL=DEBUG
   shm_size: 4G

--- a/makefiles/Makefile.base.mk
+++ b/makefiles/Makefile.base.mk
@@ -85,8 +85,17 @@ docker-test-cpu:
 docker-test-gpu:
 	docker compose -f docker-compose.test.yml run --rm --build test-gpu
 
+docker-test-cpu-benchmark:
+	docker compose -f docker-compose.test.yml run --rm --build test-cpu \
+	DOCKER_CMD="make test-cpu-benchmark"
+
+docker-test-gpu-benchmark:
+	docker compose -f docker-compose.test.yml run --rm --build test-gpu \
+	DOCKER_CMD="make test-gpu-benchmark"
+
 docker-test-all: \
-	docker-test-cpu docker-test-gpu
+	docker-test-cpu docker-test-gpu \
+	docker-test-cpu-benchmark docker-test-gpu-benchmark
 
 docker-push-cpu:
 	make .docker-push-base \


### PR DESCRIPTION
## Summary
 - split `test-benchmark` to `test-cpu-benchmark` and `test-gpu-benchmark`
 - re-add `nosd` mounts for docker tests

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
