### PR TITLE
Refactored model manager and cache model spec in inference service

### DIFF
--- a/examples/notebook/inference-client-example-det2d.ipynb
+++ b/examples/notebook/inference-client-example-det2d.ipynb
@@ -295,7 +295,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "det2d = client.Module(TaskType.OBJECT_DETECTION_2D, \"yolox/medium\")"
+    "det2d = client.Module(TaskType.OBJECT_DETECTION_2D, \"yolox/medium-trt\")\n",
+    "predictions = det2d(images=images)"
    ]
   },
   {
@@ -329,9 +330,9 @@
     "filename = f\"{str(uuid.uuid4())}.mp4\"\n",
     "writer = VideoWriter(filename)\n",
     "for idx in tqdm(range(0, len(video), 10)):\n",
-    "    img = video[idx]\n",
-    "    H, W = img.shape[:2]\n",
-    "    img = cv2.resize(img, (640, 480), interpolation=cv2.INTER_AREA)\n",
+    "    img = Image.fromarray(video[idx])\n",
+    "    W, H = img.size\n",
+    "    img = img.resize((640, 480))\n",
     "    pred = det2d(images=[img])\n",
     "    for (bboxes, scores, labels) in zip(pred[\"bboxes\"], pred[\"scores\"], pred[\"labels\"]):\n",
     "        vis = visualize_det2d(np.asarray(img).copy(), bboxes, labels)\n",

--- a/nos/client/grpc.py
+++ b/nos/client/grpc.py
@@ -327,5 +327,5 @@ class InferenceModule:
             response = self.stub.Run(request)
             response = loads(response.response_bytes)
             return response
-        except grpc.RpcError as e:
+        except Exception as e:
             raise NosClientException(f"Failed to run model {self.model_name} ({e})")

--- a/nos/common/spec.py
+++ b/nos/common/spec.py
@@ -11,6 +11,9 @@ from nos.common.types import Batch, EmbeddingSpec, ImageSpec, ImageT, TensorSpec
 from nos.protoc import import_module
 
 
+# TOFIX (spillai): Remove Any type, and explicitly define input/output types.
+FunctionSignatureType = Union[Type[int], Type[str], Type[float], Any]
+
 nos_service_pb2 = import_module("nos_service_pb2")
 
 
@@ -113,10 +116,9 @@ class FunctionSignature:
     including `inputs`, `outputs`, `func_or_cls` to be executed,
     initialization `args`/`kwargs`."""
 
-    # TOFIX (spillai): Remove Any type, and explicitly define input/output types.
-    inputs: Dict[str, Union[Type[int], Type[str], Type[float], Any]]
+    inputs: Dict[str, FunctionSignatureType]
     """Mapping of input names to dtypes."""
-    outputs: Dict[str, Union[Type[int], Type[str], Type[float], Any]]
+    outputs: Dict[str, FunctionSignatureType]
     """Mapping of output names to dtypes."""
 
     """The remaining private fields are used to instantiate a model and execute it."""
@@ -133,21 +135,22 @@ class FunctionSignature:
         """Return the function signature representation."""
         return f"FunctionSignature(inputs={self.inputs}, outputs={self.outputs}, func_or_cls={self.func_or_cls}, init_args={self.init_args}, init_kwargs={self.init_kwargs}, method_name={self.method_name})"
 
-    def _validate_inputs(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
-        """Validate the input dict against the defined signature and decode it."""
-        if len(set(self.inputs.keys()).symmetric_difference(set(inputs.keys()))) > 0:
-            raise ValueError(f"Invalid inputs, provided={set(inputs.keys())}, expected={set(self.inputs.keys())}.")
+    @staticmethod
+    def validate(inputs: Dict[str, Any], sig: Dict[str, FunctionSignatureType]) -> Dict[str, Any]:
+        """Validate the input dict against the defined signature (input or output)."""
+        if len(set(sig.keys()).symmetric_difference(set(inputs.keys()))) > 0:
+            raise ValueError(f"Invalid inputs, provided={set(inputs.keys())}, expected={set(sig.keys())}.")
         # TODO (spillai): Validate input types and shapes.
         return inputs
 
     def _encode_inputs(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Encode inputs based on defined signature."""
-        inputs = self._validate_inputs(inputs)
+        inputs = FunctionSignature.validate(inputs, self.inputs)
         return {k: dumps(v) for k, v in inputs.items()}
 
     def _decode_inputs(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Decode inputs based on defined signature."""
-        inputs = self._validate_inputs(inputs)
+        inputs = FunctionSignature.validate(inputs, self.inputs)
         return {k: loads(v) for k, v in inputs.items()}
 
     def get_inputs_spec(self) -> Dict[str, Union[ObjectTypeInfo, List[ObjectTypeInfo]]]:

--- a/nos/common/types.py
+++ b/nos/common/types.py
@@ -52,6 +52,14 @@ class TensorSpec:
         else:
             return dtype
 
+    @property
+    def nbytes(self) -> Optional[int]:
+        """Return the number of bytes required to store the tensor."""
+        try:
+            return np.prod(self.shape) * np.dtype(self.dtype).itemsize
+        except TypeError:
+            return None
+
 
 @dataclass(frozen=True)
 class ImageSpec(TensorSpec):

--- a/nos/managers/__init__.py
+++ b/nos/managers/__init__.py
@@ -1,0 +1,1 @@
+from .model import ModelHandle, ModelManager  # noqa: F401

--- a/nos/managers/model.py
+++ b/nos/managers/model.py
@@ -1,0 +1,214 @@
+import os
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List, Union
+
+import ray
+import torch
+
+from nos.common import ModelSpec
+from nos.logging import logger
+
+
+@dataclass
+class ModelHandle:
+    """Model handles for model execution.
+
+    Usage:
+        ```python
+        # Initialize a model handle
+        >> model_handle = ModelHandle(spec, num_replicas=1)
+
+        # Submit a task to the model handle
+        >> handler = model_handle.handle
+        >> response_ref = handler.submit(**model_inputs)
+
+        # Kill all actors
+        >> model_handle.kill()
+        ```
+    """
+
+    spec: ModelSpec
+    """Model specification."""
+    num_replicas: Union[int, str] = field(default=1)
+    """Number of replicas."""
+    _actors: List[Union[ray.remote, ray.actor.ActorHandle]] = field(init=False, default=None)
+    """Ray actor handle."""
+    _actor_method_func: Union[ray.remote, ray.actor.ActorHandle] = field(init=False, default=None)
+    """Ray actor method function."""
+
+    def __post_init__(self):
+        """Initialize the actor handles."""
+        if self.num_replicas > 1:
+            raise NotImplementedError("Multiple replicas not yet supported.")
+        self._actors = [self.actor_from_spec(self.spec) for _ in range(self.num_replicas)]
+        # Get the method function (i.e. `__call__`, or `predict`)
+        try:
+            self._actor_method_func = getattr(self.actor_handle, self.spec.signature.method_name)
+        except AttributeError as exc:
+            self._actor_method_func = None
+            err = f"Failed to get method function: method={self.spec.signature.method_name}"
+            logger.error(f"{err}, exc={exc}")
+            raise Exception(err)
+
+    @staticmethod
+    def actor_from_spec(spec: ModelSpec) -> Union[ray.remote, ray.actor.ActorHandle]:
+        """Get an actor handle from model specification.
+
+        Args:
+            spec (ModelSpec): Model specification.
+        Returns:
+            Union[ray.remote, ray.actor.ActorHandle]: Ray actor handle.
+        """
+        # TODO (spillai): Use the auto-tuned model spec to instantiate an
+        # actor the desired memory requirements. Fractional GPU amounts
+        # will need to be calculated from the target HW and model spec
+        # (i.e. 0.5 on A100 vs. T4 are different).
+        model_cls = spec.signature.func_or_cls
+        actor_options = {"num_gpus": 0.5 if torch.cuda.is_available() else 0}
+        logger.debug(f"Creating actor: {actor_options}, {model_cls}")
+        actor_cls = ray.remote(**actor_options)(model_cls)
+        return actor_cls.remote(*spec.signature.init_args, **spec.signature.init_kwargs)
+
+    def kill(self) -> None:
+        """Kill the actor handle."""
+        for actor_handle in self._actors:
+            ray.kill(actor_handle)
+
+    def remote(self, *args, **kwargs) -> ray.ObjectRef:
+        """Submit a task to the actor handle or pool.
+
+        Args:
+            *args: Variable length argument list.
+            **kwargs: Arbitrary keyword arguments.
+        Returns:
+            ray.ObjectRef: Ray object reference.
+        """
+        # Call the method function
+        response_ref: ray.ObjectRef = self._actor_method_func.remote(**kwargs)
+        return ray.get(response_ref)
+
+    @property
+    def actor_handle(self) -> Union[ray.remote, ray.actor.ActorHandle]:
+        """Get the actor handle."""
+        assert len(self._actors) == 1, "Only one actor handle is supported."
+        return self._actors[0]
+
+
+@dataclass(frozen=True)
+class ModelManager:
+    """Model manager for serving models with ray actors.
+
+    Features:
+      * Concurrency: Support fixed number of concurrent models,
+        running simultaneously with FIFO model eviction policies.
+      * Parallelism: Support multiple replicas of the same model.
+      * Optimal memory management: Model memory consumption
+        are automatically inferred from the model specification
+        and used to optimally bin-pack models on the GPU.
+      * Automatic garbage collection: Models are automatically
+        garbage collected when they are evicted from the manager.
+        Scaling models with the model manager should not result in OOM.
+
+    """
+
+    class EvictionPolicy(str, Enum):
+        FIFO = "FIFO"
+        LRU = "LRU"
+
+    policy: EvictionPolicy = EvictionPolicy.FIFO
+    """Eviction policy."""
+
+    max_concurrent_models: int = int(os.getenv("NOS_MAX_CONCURRENT_MODELS", 2))
+    """Maximum number of concurrent models."""
+
+    handlers: Dict[str, ModelHandle] = field(default_factory=OrderedDict)
+    """Model handles."""
+
+    def __post_init__(self):
+        if self.policy not in (self.EvictionPolicy.FIFO,):
+            raise NotImplementedError(f"Eviction policy not implemented: {self.policy}")
+
+    def __repr__(self) -> str:
+        """String representation of the model manager (memory consumption, models, in tabular format etc)."""
+        repr_str = f"ModelManager(policy={self.policy}, len(handlers)={len(self.handlers)})"
+        for idx, (model_id, model_handle) in enumerate(self.handlers.items()):
+            repr_str += f"\n\t{idx}: {model_id}, {model_handle}"
+        return repr_str
+
+    def __contains__(self, spec: ModelSpec) -> bool:
+        """Check if a model exists in the manager.
+
+        Args:
+            spec (ModelSpec): Model specification.
+        Returns:
+            bool: True if the model exists, else False.
+        """
+        return spec.id in self.handlers
+
+    def get(self, model_spec: ModelSpec) -> ModelHandle:
+        """Get a model handle from the manager.
+
+        Create a new model handle if it does not exist,
+        else return an existing handle.
+
+        Args:
+            model_spec (ModelSpec): Model specification.
+        Returns:
+            ModelHandle: Model handle.
+        """
+        model_id: str = model_spec.id
+        if model_id not in self.handlers:
+            return self.add(model_spec)
+        else:
+            return self.handlers[model_id]
+
+    def add(self, spec: ModelSpec) -> ModelHandle:
+        """Add a model to the manager.
+
+        Args:
+            spec (ModelSpec): Model specification.
+        Raises:
+            ValueError: If the model already exists.
+        Returns:
+            ModelHandle: Model handle.
+        """
+        # If the model already exists, raise an error
+        model_id = spec.id
+        if model_id in self.handlers:
+            raise ValueError(f"Model already exists: {model_id}")
+
+        # If the model handle is full, pop the oldest model
+        if len(self.handlers) >= self.max_concurrent_models:
+            _handle: ModelHandle = self.evict()
+            logger.debug(f"Deleting oldest model: {_handle.spec.name}")
+
+        # Create the serve deployment from the model handle
+        logger.debug(f"Initializing model with spec: {spec.name}")
+
+        # Note: Currently one model per (model-name, task) is supported.
+        self.handlers[model_id] = ModelHandle(spec)
+        logger.debug(f"Created actor: {self.handlers[model_id]}, type={type(self.handlers[model_id])}")
+        logger.debug(f"Models ({len(self.handlers)}): {self.handlers.keys()}")
+
+        return self.handlers[model_id]
+
+    def evict(self) -> ModelHandle:
+        """Evict a model from the manager (FIFO, LRU etc).
+
+        Returns:
+            ModelHandle: Model handle.
+        """
+        # Pop the oldest model
+        # TODO (spillai): Implement LRU policy
+        assert len(self.handlers) > 0, "No models to evict."
+        _, handle = self.handlers.popitem(last=False)
+        model_id = handle.spec.id
+        logger.debug(f"Deleting model: {model_id}")
+
+        # Explicitly kill the model handle (including all actors)
+        handle.kill()
+        logger.debug(f"Deleted model: {model_id}")
+        assert model_id not in self.handlers, f"Model should have been evicted: {model_id}"
+        return handle

--- a/nos/server/service.py
+++ b/nos/server/service.py
@@ -1,14 +1,9 @@
-import os
-from collections import OrderedDict
-from dataclasses import dataclass, field
-from enum import Enum
-from typing import Any, Dict, List, Union
+import traceback
+from typing import Any, Dict
 
 import grpc
-import ray
 import rich.console
 import rich.status
-import torch
 from google.protobuf import empty_pb2
 
 from nos import hub
@@ -17,187 +12,13 @@ from nos.constants import DEFAULT_GRPC_PORT  # noqa F401
 from nos.exceptions import ModelNotFoundError
 from nos.executors.ray import RayExecutor
 from nos.logging import logger
+from nos.managers import ModelHandle, ModelManager
 from nos.protoc import import_module
 from nos.version import __version__
 
 
 nos_service_pb2 = import_module("nos_service_pb2")
 nos_service_pb2_grpc = import_module("nos_service_pb2_grpc")
-
-
-@dataclass
-class ModelHandle:
-    """Model handles for serving models.
-
-    Usage:
-        ```python
-        # Initialize a model handle
-        >> model_handle = ModelHandle(spec, num_replicas=1)
-
-        # Submit a task to the model handle
-        >> handler = model_handle.handle
-        >> response_ref = handler.submit(**model_inputs)
-
-        # Kill all actors
-        >> model_handle.kill()
-        ```
-    """
-
-    spec: ModelSpec
-    """Model specification."""
-    num_replicas: Union[int, str] = field(default=1)
-    """Number of replicas."""
-
-    _actors: List[Union[ray.remote, ray.actor.ActorHandle]] = field(init=False, default=None)
-    """Ray actor handle."""
-
-    def __post_init__(self):
-        """Initialize the actor handles."""
-        if self.num_replicas > 1:
-            raise NotImplementedError("Multiple replicas not yet supported.")
-        self._actors = [self.actor_from_spec(self.spec) for _ in range(self.num_replicas)]
-
-    @staticmethod
-    def actor_from_spec(spec: ModelSpec) -> Union[ray.remote, ray.actor.ActorHandle]:
-        """Get an actor handle from model specification."""
-        # TODO (spillai): Use the auto-tuned model spec to instantiate an
-        # actor the desired memory requirements. Fractional GPU amounts
-        # will need to be calculated from the target HW and model spec
-        # (i.e. 0.5 on A100 vs. T4 are different).
-        model_cls = spec.signature.func_or_cls
-        actor_options = {"num_gpus": 0.5 if torch.cuda.is_available() else 0}
-        logger.debug(f"Creating actor: {actor_options}, {model_cls}")
-        actor_cls = ray.remote(**actor_options)(model_cls)
-        return actor_cls.remote(*spec.signature.init_args, **spec.signature.init_kwargs)
-
-    def kill(self) -> None:
-        """Kill the actor handle."""
-        for actor_handle in self._actors:
-            ray.kill(actor_handle)
-
-    def remote(self, *args, **kwargs) -> ray.ObjectRef:
-        """Submit a task to the actor handle or pool."""
-        # Get the method function (i.e. `__call__`, or `predict`)
-        try:
-            actor_method_func = getattr(self.actor_handle, self.spec.signature.method_name)
-        except AttributeError as exc:
-            err = f"Failed to get method function: method={self.spec.signature.method_name}"
-            logger.error(f"{err}, exc={exc}")
-            raise Exception(err)
-
-        # Call the method function
-        response_ref: ray.ObjectRef = actor_method_func.remote(**kwargs)
-        return ray.get(response_ref)
-
-    @property
-    def actor_handle(self) -> Union[ray.remote, ray.actor.ActorHandle]:
-        """Get the actor handle."""
-        assert len(self._actors) == 1, "Only one actor handle is supported."
-        return self._actors[0]
-
-
-@dataclass(frozen=True)
-class ModelManager:
-    """Model manager for serving models with ray actors.
-
-    Features:
-      * Concurrency: Support fixed number of concurrent models,
-        running simultaneously with FIFO model eviction policies.
-      * Parallelism: Support multiple replicas of the same model.
-      * Optimal memory management: Model memory consumption
-        are automatically inferred from the model specification
-        and used to optimally bin-pack models on the GPU.
-      * Automatic garbage collection: Models are automatically
-        garbage collected when they are evicted from the manager.
-        Scaling models with the model manager should not result in OOM.
-
-    """
-
-    class EvictionPolicy(str, Enum):
-        FIFO = "FIFO"
-        LRU = "LRU"
-
-    policy: EvictionPolicy = EvictionPolicy.FIFO
-    """Eviction policy."""
-
-    max_concurrent_models: int = int(os.getenv("NOS_MAX_CONCURRENT_MODELS", 2))
-    """Maximum number of concurrent models."""
-
-    handlers: Dict[str, ModelHandle] = field(default_factory=OrderedDict)
-    """Model handles."""
-
-    def __post_init__(self):
-        if self.policy not in (self.EvictionPolicy.FIFO,):
-            raise NotImplementedError(f"Eviction policy not implemented: {self.policy}")
-
-    def __repr__(self) -> str:
-        """String representation of the model manager (memory consumption, models, in tabular format etc)."""
-        repr_str = f"ModelManager(policy={self.policy}, len(handlers)={len(self.handlers)})"
-        for idx, (model_id, model_handle) in enumerate(self.handlers.items()):
-            repr_str += f"\n\t{idx}: {model_id}, {model_handle}"
-        return repr_str
-
-    def get(self, model_spec: ModelSpec) -> ModelHandle:
-        """Get a model handle from the manager.
-
-        Create a new model handle if it does not exist,
-        else return an existing handle.
-
-        Args:
-            model_spec (ModelSpec): Model specification.
-        Returns:
-            ModelHandle: Model handle.
-        """
-        model_id: str = model_spec.id
-        if model_id not in self.handlers:
-            return self.add(model_spec)
-        else:
-            return self.handlers[model_id]
-
-    @logger.catch
-    def add(self, spec: ModelSpec) -> ModelHandle:
-        """Add a model to the manager.
-
-        Args:
-            spec (ModelSpec): Model specification.
-        Returns:
-            ModelHandle: Model handle.
-        """
-        # If the model already exists, raise an error
-        model_id = spec.id
-        if model_id in self.handlers:
-            raise ValueError(f"Model already exists: {model_id}")
-
-        # If the model handle is full, pop the oldest model
-        if len(self.handlers) >= self.max_concurrent_models:
-            _handle: ModelHandle = self.evict()
-            logger.info(f"Deleting oldest model: {_handle.spec.name}")
-
-        # Create the serve deployment from the model handle
-        logger.info(f"Initializing model with spec: {spec.name}")
-
-        # Note: Currently one model per (model-name, task) is supported.
-        self.handlers[model_id] = ModelHandle(spec)
-        logger.info(f"Created actor: {self.handlers[model_id]}, type={type(self.handlers[model_id])}")
-        logger.info(f"Models ({len(self.handlers)}): {self.handlers.keys()}")
-
-        return self.handlers[model_id]
-
-    @logger.catch
-    def evict(self) -> ModelHandle:
-        """Evict a model from the manager (FIFO, LRU etc)."""
-        # Pop the oldest model
-        # TODO (spillai): Implement LRU policy
-        assert len(self.handlers) > 0, "No models to evict."
-        _, handle = self.handlers.popitem(last=False)
-        model_id = handle.spec.id
-        logger.info(f"Deleting model: {model_id}")
-
-        # Explicitly kill the model handle (including all actors)
-        handle.kill()
-        logger.info(f"Deleted model: {model_id}")
-        assert model_id not in self.handlers, f"Model should have been evicted: {model_id}"
-        return handle
 
 
 class InferenceService:
@@ -218,8 +39,9 @@ class InferenceService:
         except Exception as e:
             logger.info(f"Failed to initialize executor: {e}")
             raise RuntimeError(f"Failed to initialize executor: {e}")
+        self.current_model_id = None
+        self.current_model_spec = None
 
-    @logger.catch
     def execute(self, model_name: str, task: TaskType = None, inputs: Dict[str, Any] = None) -> Dict[str, Any]:
         """Execute the model.
 
@@ -230,12 +52,19 @@ class InferenceService:
         Returns:
             Dict[str, Any]: Model outputs.
         """
-        # Load the model spec
-        try:
-            model_spec: ModelSpec = hub.load_spec(model_name, task=task)
-            logger.debug(f"Loaded model spec: {model_spec}")
-        except Exception as e:
-            raise ModelNotFoundError(f"Failed to load model spec: {model_name}, {e}")
+        # Load model spec if the model has changed
+        if self.current_model_id is None or self.current_model_id != (model_name, task.value):
+            # Load the model spec
+            try:
+                model_spec: ModelSpec = hub.load_spec(model_name, task=task)
+                logger.debug(f"Loaded model spec: {model_spec}")
+            except Exception as e:
+                raise ModelNotFoundError(f"Failed to load model spec: {model_name}, {e}")
+            self.current_model_id = (model_name, task.value)
+            self.current_model_spec = model_spec
+
+        assert self.current_model_spec is not None
+        model_spec = self.current_model_spec
 
         # TODO (spillai): Validate/Decode the inputs
         model_inputs = model_spec.signature._decode_inputs(inputs)
@@ -246,7 +75,7 @@ class InferenceService:
         model_handle: ModelHandle = self.model_manager.get(model_spec)
 
         # Get the model handle and call it remotely (with model spec, actor handle)
-        response = model_handle.remote(**model_inputs)
+        response: Dict[str, Any] = model_handle.remote(**model_inputs)
 
         # If the response is a single value, wrap it in a dict with the appropriate key
         if len(model_spec.signature.outputs) == 1:
@@ -268,19 +97,16 @@ class InferenceServiceImpl(nos_service_pb2_grpc.InferenceServiceServicer, Infere
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    @logger.catch
     def Ping(self, request: empty_pb2.Empty, context: grpc.ServicerContext) -> nos_service_pb2.PingResponse:
         """Health check."""
         return nos_service_pb2.PingResponse(status="ok")
 
-    @logger.catch
     def GetServiceInfo(
         self, request: empty_pb2.Empty, context: grpc.ServicerContext
     ) -> nos_service_pb2.ServiceInfoResponse:
         """Get information on the service."""
         return nos_service_pb2.ServiceInfoResponse(version=__version__)
 
-    @logger.catch
     def ListModels(self, request: empty_pb2.Empty, context: grpc.ServicerContext) -> nos_service_pb2.ModelListResponse:
         """List all models."""
         response = nos_service_pb2.ModelListResponse()
@@ -288,7 +114,6 @@ class InferenceServiceImpl(nos_service_pb2_grpc.InferenceServiceServicer, Infere
             response.models.append(nos_service_pb2.ModelInfo(name=spec.name, task=spec.task.value))
         return response
 
-    @logger.catch
     def GetModelInfo(
         self, request: nos_service_pb2.ModelInfoRequest, context: grpc.ServicerContext
     ) -> nos_service_pb2.ModelInfoResponse:
@@ -297,10 +122,10 @@ class InferenceServiceImpl(nos_service_pb2_grpc.InferenceServiceServicer, Infere
             model_info = request.request
             spec: ModelSpec = hub.load_spec(model_info.name, task=TaskType(model_info.task))
         except KeyError as e:
-            context.abort(context, grpc.StatusCode.NOT_FOUND, str(e))
+            logger.error(f"Failed to load spec: [request={request.request}, e={e}]")
+            context.abort(grpc.StatusCode.NOT_FOUND, str(e))
         return spec._to_proto(public=True)
 
-    @logger.catch
     def Run(
         self, request: nos_service_pb2.InferenceRequest, context: grpc.ServicerContext
     ) -> nos_service_pb2.InferenceResponse:
@@ -314,15 +139,17 @@ class InferenceServiceImpl(nos_service_pb2_grpc.InferenceServiceServicer, Infere
             TaskType.OBJECT_DETECTION_2D.value,
             TaskType.IMAGE_SEGMENTATION_2D.value,
         ):
-            context.abort(context, grpc.StatusCode.NOT_FOUND, f"Invalid task {model_request.task}")
+            context.abort(grpc.StatusCode.NOT_FOUND, f"Invalid task {model_request.task}")
 
         try:
             logger.debug(f"Executing request: {model_request.task}, {model_request.name}")
             response = self.execute(model_request.name, task=TaskType(model_request.task), inputs=request.inputs)
             return nos_service_pb2.InferenceResponse(response_bytes=dumps(response))
-        except Exception as exc:
-            logger.error(f"Failed to execute request: {model_request.task}, {model_request.name}, {request.inputs}")
-            context.abort(context, grpc.StatusCode.INTERNAL, str(exc))
+        except (grpc.RpcError, Exception) as e:
+            msg = f"Failed to execute request: {model_request.task}, {model_request.name}"
+            msg += f"{traceback.format_exc()}"
+            logger.error(f"{msg}, e={e}")
+            context.abort(grpc.StatusCode.INTERNAL, "Internal Server Error")
 
 
 def serve(address: str = f"[::]:{DEFAULT_GRPC_PORT}", max_workers: int = 1) -> None:

--- a/nos/test/conftest.py
+++ b/nos/test/conftest.py
@@ -30,7 +30,7 @@ def ray_executor():
 
 
 @pytest.fixture(scope="session")
-def grpc_server():
+def grpc_server(ray_executor):
     """Test gRPC server (Port: 50052)."""
     from loguru import logger
 
@@ -101,7 +101,7 @@ def grpc_server_docker_runtime_cpu():
     assert status is not None and status == "running"
 
     # Yield the running container
-    yield container
+    yield runtime
 
     # Tear down
     try:
@@ -137,7 +137,7 @@ def grpc_server_docker_runtime_gpu():
     assert status is not None and status == "running"
 
     # Yield the running container
-    yield container
+    yield runtime
 
     # Tear down
     try:

--- a/tests/client/grpc/conftest.py
+++ b/tests/client/grpc/conftest.py
@@ -2,11 +2,25 @@ import pytest
 from loguru import logger
 
 from nos.test.conftest import (  # noqa: F401, E402  # noqa: F401, E402
+    grpc_client,
     grpc_client_cpu,
     grpc_client_gpu,
+    grpc_server,
     grpc_server_docker_runtime_cpu,
     grpc_server_docker_runtime_gpu,
+    ray_executor,
 )
+
+
+@pytest.fixture(scope="session")
+def local_grpc_client_with_server(grpc_server, grpc_client):  # noqa: F811
+    """Test local gRPC client with local runtime (Port: 50052)."""
+    # Wait for server to start
+    grpc_client.WaitForServer(timeout=180, retry_interval=5)
+    logger.info("Server started!")
+
+    # Yield the gRPC client once the server is up and initialized
+    yield grpc_client
 
 
 @pytest.fixture(scope="session")

--- a/tests/client/grpc/test_grpc_client_e2e.py
+++ b/tests/client/grpc/test_grpc_client_e2e.py
@@ -18,7 +18,6 @@ from nos.common import ModelSpec, TaskType  # noqa: E402
 from nos.test.utils import NOS_TEST_IMAGE  # noqa: E402
 
 
-@pytest.mark.skip(reason="This test is not ready yet.")
 @pytest.mark.client
 def test_e2e_grpc_client_and_gpu_server(grpc_client_with_gpu_backend):  # noqa: F811
     """Test the gRPC client with GPU docker runtime initialized.
@@ -71,7 +70,7 @@ def test_e2e_grpc_client_and_gpu_server(grpc_client_with_gpu_backend):  # noqa: 
     model = client.Module(task=task, model_name=model_name)
     assert model is not None
     assert model.GetModelInfo() is not None
-    for _ in tqdm(range(1), desc=f"Bench [task={task}, model_name={model_name}]"):
+    for _ in tqdm(range(1), desc=f"Test [task={task}, model_name={model_name}]"):
         response = model(texts=["a cat dancing on the grass."])
         assert isinstance(response, dict)
         assert "embedding" in response
@@ -81,8 +80,8 @@ def test_e2e_grpc_client_and_gpu_server(grpc_client_with_gpu_backend):  # noqa: 
     model = client.Module(task=task, model_name=model_name)
     assert model is not None
     assert model.GetModelInfo() is not None
-    for _ in tqdm(range(1), desc=f"Bench [task={task}, model_name={model_name}]"):
-        response = model(img=img)
+    for _ in tqdm(range(1), desc=f"Test [task={task}, model_name={model_name}]"):
+        response = model(images=img)
         assert isinstance(response, dict)
         assert "embedding" in response
 
@@ -91,7 +90,7 @@ def test_e2e_grpc_client_and_gpu_server(grpc_client_with_gpu_backend):  # noqa: 
     model = client.Module(task=task, model_name=model_name)
     assert model is not None
     assert model.GetModelInfo() is not None
-    for _ in tqdm(range(1), desc=f"Bench [task={task}, model_name={model_name}]"):
+    for _ in tqdm(range(1), desc=f"Test [task={task}, model_name={model_name}]"):
         response = model(images=[img])
         assert isinstance(response, dict)
 
@@ -102,12 +101,13 @@ def test_e2e_grpc_client_and_gpu_server(grpc_client_with_gpu_backend):  # noqa: 
     model = client.Module(task=task, model_name=model_name)
     assert model is not None
     assert model.GetModelInfo() is not None
-    for _ in tqdm(range(1), desc=f"Bench [task={task}, model_name={model_name}]"):
+    for _ in tqdm(range(1), desc=f"Test [task={task}, model_name={model_name}]"):
         response = model(prompts=["a cat dancing on the grass."], width=512, height=512, num_images=1)
         assert isinstance(response, dict)
         assert "images" in response
 
 
+@pytest.mark.skip(reason="CPU backend is not ready yet")
 @pytest.mark.client
 def test_e2e_grpc_client_and_cpu_server(grpc_client_with_cpu_backend):  # noqa: F811
     """Test the gRPC client with CPU docker runtime initialized.
@@ -156,7 +156,7 @@ def test_e2e_grpc_client_and_cpu_server(grpc_client_with_cpu_backend):  # noqa: 
     model = client.Module(task=task, model_name=model_name)
     assert model is not None
     assert model.GetModelInfo() is not None
-    for _ in tqdm(range(1), desc=f"Bench [task={task}, model_name={model_name}]"):
+    for _ in tqdm(range(1), desc=f"Test [task={task}, model_name={model_name}]"):
         response = model(texts=["a cat dancing on the grass."])
         assert isinstance(response, dict)
         assert "embedding" in response
@@ -166,7 +166,7 @@ def test_e2e_grpc_client_and_cpu_server(grpc_client_with_cpu_backend):  # noqa: 
     model = client.Module(task=task, model_name=model_name)
     assert model is not None
     assert model.GetModelInfo() is not None
-    for _ in tqdm(range(1), desc=f"Bench [task={task}, model_name={model_name}]"):
+    for _ in tqdm(range(1), desc=f"Test [task={task}, model_name={model_name}]"):
         response = model(images=[img])
         assert isinstance(response, dict)
         assert "embedding" in response
@@ -176,18 +176,17 @@ def test_e2e_grpc_client_and_cpu_server(grpc_client_with_cpu_backend):  # noqa: 
     model = client.Module(task=task, model_name=model_name)
     assert model is not None
     assert model.GetModelInfo() is not None
-    for _ in tqdm(range(1), desc=f"Bench [task={task}, model_name={model_name}]"):
+    for _ in tqdm(range(1), desc=f"Test [task={task}, model_name={model_name}]"):
         response = model(images=[img])
         assert isinstance(response, dict)
         assert "bboxes" in response
         assert "labels" in response
         assert "scores" in response
 
-    # TXT2IMG (not supported in CPU yet)
+    # TXT2IMG
     task, model_name = TaskType.IMAGE_GENERATION, "stabilityai/stable-diffusion-2"
     model = client.Module(task=task, model_name=model_name)
     assert model is not None
     assert model.GetModelInfo() is not None
-    with pytest.raises(Exception):
-        for _ in tqdm(range(1), desc=f"Bench [task={task}, model_name={model_name}]"):
-            response = model(prompts=["a cat dancing on the grass."])
+    for _ in tqdm(range(1), desc=f"Test [task={task}, model_name={model_name}]"):
+        response = model(prompts=["a cat dancing on the grass."], width=512, height=512, num_images=1)

--- a/tests/common/test_common_types.py
+++ b/tests/common/test_common_types.py
@@ -43,6 +43,9 @@ def test_common_types():
     if has_torch:
         ImageT[torch.Tensor]
 
+    assert TensorSpec(shape=(None, None, 3), dtype="float32").nbytes is None
+    assert TensorSpec(shape=(480, 640, 3), dtype="float32").nbytes == 480 * 640 * 3 * 4
+
 
 def test_common_batch_types():
     T = TypeVar("T")

--- a/tests/hub/test_hub_inference.py
+++ b/tests/hub/test_hub_inference.py
@@ -8,7 +8,11 @@ from nos.test.utils import skip_if_no_torch_cuda
 def hub_image_models():
     models = hub.list()
     assert len(models) > 0
-    return [spec for spec in models if spec.task in (TaskType.IMAGE_EMBEDDING, TaskType.OBJECT_DETECTION_2D)]
+    return [
+        spec
+        for spec in models
+        if spec.task in (TaskType.IMAGE_EMBEDDING, TaskType.OBJECT_DETECTION_2D) and not spec.name.endswith("trt")
+    ]
 
 
 @skip_if_no_torch_cuda

--- a/tests/managers/test_model_manager.py
+++ b/tests/managers/test_model_manager.py
@@ -1,0 +1,115 @@
+import numpy as np
+import pytest
+from loguru import logger
+
+from nos import hub
+from nos.managers import ModelHandle, ModelManager
+from nos.test.conftest import ray_executor  # noqa: F401
+
+
+@pytest.fixture
+def manager(ray_executor):  # noqa: F811
+    manager = ModelManager()
+    assert manager is not None
+
+    yield manager
+
+
+def test_model_manager(manager):  # noqa: F811
+    # Test adding several models back to back with the same manager.
+    # This should not raise any OOM errors as models are evicted
+    # from the manager's cache.
+    for idx, spec in enumerate(hub.list()):
+        # Note: `manager.get()` is a wrapper around `manager.add()`
+        # and creates a single replica of the model.
+        handler: ModelHandle = manager.get(spec)
+        assert handler is not None
+        assert isinstance(handler, ModelHandle)
+
+        logger.debug(">" * 80)
+        logger.debug(f"idx: {idx}")
+        logger.debug(f"Model manager: {manager}, spec: {spec}")
+
+    # Check if the model manager contains the model.
+    assert spec in manager
+
+
+def test_model_manager_errors(manager):
+    # Get model specs
+    spec = None
+    for _, _spec in enumerate(hub.list()):
+        spec = _spec
+        break
+
+    # Re-adding the same model twice should raise a `ValueError`.
+    manager.add(spec)
+    assert spec in manager
+    with pytest.raises(ValueError):
+        manager.add(spec)
+
+    # Creating a model with num_replicas > 1 should raise a `NotImplementedError`.
+    with pytest.raises(NotImplementedError):
+        ModelHandle(spec, num_replicas=2)
+
+    # Creating a model with an invalid eviction policy should raise a `NotImplementedError`.
+    with pytest.raises(NotImplementedError):
+        ModelManager(policy=ModelManager.EvictionPolicy.LRU)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "openai/clip-vit-base-patch32",
+    ],
+)
+@pytest.mark.parametrize("scale", [1, 8])
+def test_model_manager_inference(model_name, scale, manager):  # noqa: F811
+    """Benchmark the model manager with a single model."""
+    import time
+
+    from PIL import Image
+    from tqdm import tqdm
+
+    from nos.common import TaskType
+    from nos.test.utils import NOS_TEST_IMAGE
+
+    img = Image.open(NOS_TEST_IMAGE)
+    W, H = 224, 224
+    img = img.resize((W * scale, H * scale))
+    img = np.asarray(img)
+
+    # Load a model spec
+    task = TaskType.IMAGE_EMBEDDING
+    spec = hub.load_spec(model_name, task=task)
+
+    # Add the model to the manager (or via `manager.add()`)
+    handle: ModelHandle = manager.get(spec)
+    assert handle is not None
+
+    # Warmup
+    for _ in tqdm(range(10), desc=f"Warmup model={model_name}, B=1", total=0):
+        images = [img]
+        result = handle.remote(images=images)
+        assert result is not None
+        assert isinstance(result, np.ndarray)
+
+    # Benchmark (10s)
+    for b in range(0, 8):
+        B = 2**b
+        images = [img for _ in range(B)]
+        st = time.time()
+        for _ in tqdm(
+            range(100_000),
+            desc=f"Benchmark model={model_name}, task={task} [B={B}, shape={img.shape}]",
+            unit="images",
+            unit_scale=B,
+            total=0,
+        ):
+            embedding = handle.remote(images=images)
+            assert embedding is not None
+            assert isinstance(embedding, np.ndarray)
+            N, _ = embedding.shape
+            assert N == B
+            if time.time() - st > 10.0:
+                break


### PR DESCRIPTION
## Summary

- Refactored model manager to be a separate module, with additional tests and runtime checks on method attributes/names.
- Model spec is now cached and checked on every execute to avoid having to reload model spec on every inference request.

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
