### PR TITLE
YOLOX compilation workflow with new Torch TRT compilation backend

### DIFF
--- a/nos/compilers/__init__.py
+++ b/nos/compilers/__init__.py
@@ -1,0 +1,161 @@
+import contextlib
+import io
+import time
+from dataclasses import dataclass
+from typing import Any, Dict
+
+import torch
+from torch.fx import Tracer
+from transformers.utils.fx import HFTracer
+
+from nos.logging import logger
+
+
+NOSTracer = HFTracer
+
+
+@dataclass(frozen=True)
+class NOSCompilerOptions:
+    """Options for the NOS compiler."""
+
+    verbose: bool = False
+    """Whether to print verbose logs."""
+    tracer_cls: torch.fx.Tracer = NOSTracer
+    """Tracer class to use for tracing."""
+    return_intermediates: bool = False
+    """Whether to return intermediate results
+    such as traced model and compiled model."""
+
+
+@dataclass(frozen=True)
+class NOSCompilerOutput:
+    args: Dict[str, Any]
+    """Arguments used for tracing."""
+    concrete_args: Dict[str, Any]
+    """Concrete arguments used for tracing."""
+    precision: torch.dtype
+    """Precision of the traced model."""
+    options: NOSCompilerOptions
+    """Tracer class used for tracing."""
+    traced_model: torch.nn.Module = None
+    """Traced model."""
+    compiled_model: torch.nn.Module = None
+    """Compiled model."""
+
+
+def compile(
+    model: torch.nn.Module,
+    cargs: Dict[str, Any],
+    concrete_args: Dict[str, Any] = None,
+    precision: torch.dtype = torch.float32,
+    options: NOSCompilerOptions = NOSCompilerOptions(),
+    slug: str = None,
+) -> torch.nn.Module:
+    """ "Compile a model with NOS.
+
+    Args:
+        model: Model to compile.
+        args: Arguments to use for tracing.
+        concrete_args: Concrete arguments to use for tracing.
+        precision: Precision to use for tracing.
+        options: Options for the NOS compiler.
+
+    Returns:
+        torch.nn.Module: Compiled model.
+    """
+    assert isinstance(model, torch.nn.Module)
+    assert precision in (torch.float32, torch.float16), "Precision must be one of: float32, float16"
+    assert options.tracer_cls in (
+        NOSTracer,
+        HFTracer,
+        Tracer,
+    ), "Tracer must be one of: NOSTracer, huggingface.fx.HFTracer, torch.fx.Tracer"
+    assert torch.cuda.is_available(), "Cannot compile model without CUDA support"
+
+    import torch_tensorrt
+    from torch_tensorrt.fx.utils import LowerPrecision
+
+    def log_mem_usage():
+        logger.debug(
+            f"Memory usage (device | free | total): {device_id} | {free / 1024 ** 3:.1f} | {total / 1024 ** 3:.1f} GiB"
+        )
+
+    st = time.time()
+    if slug is None:
+        model_cls = model.__class__
+        slug = f"{model_cls.__module__}.{model_cls.__name__}"
+    logger.debug(f"Tracing {slug} with NOS")
+    try:
+        concrete_args = concrete_args or {}
+        tracer = options.tracer_cls()
+        traced_graph = tracer.trace(model, concrete_args=concrete_args, dummy_inputs=cargs)
+        traced_model = torch.fx.GraphModule(model, traced_graph)
+        if options.verbose:
+            logger.debug(">" * 80)
+            logger.debug(f"Traced {slug}")
+            with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+                traced_graph.print_tabular()
+                logger.debug(buf.getvalue())
+            logger.debug(">" * 80)
+    except Exception as e:
+        logger.error(f"Failed to trace model: {e}")
+        raise e
+    logger.debug(f"Traced {slug} in {time.time() - st:.2f}s")
+
+    st = time.time()
+    logger.debug(f"Compiling {slug} with NOS")
+    device_id = torch.cuda.current_device()
+    free, total = torch.cuda.mem_get_info(device_id)
+    log_mem_usage()
+
+    max_workspace_size = free // 2
+    logger.debug(f"Compiling with max_workspace_size = {max_workspace_size / 1024 ** 3:.1f} GiB")
+    try:
+        trt_model = torch_tensorrt.fx.compile(
+            traced_model,
+            list(cargs.values()),
+            min_acc_module_size=5,
+            max_batch_size=2048,
+            max_workspace_size=max_workspace_size,
+            explicit_batch_dimension=True,
+            lower_precision=LowerPrecision.FP32 if precision == torch.float32 else LowerPrecision.FP16,
+            verbose_log=options.verbose,
+            timing_cache_prefix="",
+            save_timing_cache=False,
+            cuda_graph_batch_size=-1,
+            dynamic_batch=False,
+            is_aten=False,
+            use_experimental_fx_rt=False,
+        )
+        assert callable(trt_model), "Compiled model must be callable"
+    except Exception as e:
+        logger.error(f"Failed to compile {slug}: {e}, skipping compilation")
+        raise e
+        return None
+    logger.debug(f"Compiled {slug} in {time.time() - st:.2f}s")
+
+    # Finally, we use Torch utilities to clean up the workspace
+    logger.debug("Cleaning up workspace")
+    log_mem_usage()
+    torch._dynamo.reset()
+    with torch.no_grad():
+        torch.cuda.empty_cache()
+    del model
+
+    if options.return_intermediates:
+        logger.warning(
+            f"Returning intermediate compilation results for {slug}, remember to cleanup traced models manually"
+        )
+        log_mem_usage()
+        return NOSCompilerOutput(
+            args=cargs,
+            concrete_args=concrete_args,
+            precision=precision,
+            options=options,
+            traced_model=traced_model,
+            compiled_model=trt_model,
+        )
+
+    del traced_model
+    del traced_graph
+    return trt_model

--- a/tests/compilers/test_torchtrt_yolox_compilation.py
+++ b/tests/compilers/test_torchtrt_yolox_compilation.py
@@ -1,0 +1,81 @@
+"""Test and benchmark YOLOX compilation with TorchTRT.
+
+On NVIDIA 4090:
+
+On (1x3x640x480):
+ - torch-eager | yolox/medium: 1867it [00:20,  93.33it/s]
+ - torch-eager | yolox/large:  1500it [00:20, 74.97it/s]
+
+ -   torch-trt | yolox/tiny:   3722it [00:20, 186.08it/s]
+ -   torch-trt | yolox/small:  3686it [00:20, 184.28it/s]
+ -   torch-trt | yolox/medium: 3352it [00:20, 167.57it/s]
+ -   torch-trt | yolox/large:  2617it [00:20, 130.83it/s]
+ -   torch-trt | yolox/xlarge: 1812it [00:20, 90.57it/s]
+
+On (1x3x1280x960):
+-    torch-trt | yolox/tiny:   2052it [00:20, 102.58it/s]
+-    torch-trt | yolox/small:  1990it [00:20, 99.50it/s]
+-    torch-trt | yolox/medium: 1480it [00:20, 73.96it/s]
+-    torch-trt | yolox/large:  1056it [00:20, 52.80it/s]
+-    torch-trt | yolox/xlarge:  682it [00:20, 34.05it/s]
+
+
+ Currently yolox/nano does not compile due to accuracy issues.
+    AssertionError: Pass <function Lowerer.__call__.<locals>.do_lower at 0x7fdaf2e51af0> failed correctness check due at output 1:
+    Tensor-likes are not close!
+
+    Mismatched elements: 17 / 153600 (0.0%)
+    Greatest absolute difference: 0.21282958984375 at index (0, 82, 1, 32) (up to 0.1 allowed)
+    Greatest relative difference: 10.422420572267951 at index (0, 34, 23, 4) (up to 0.1 allowed)
+"""
+import os
+
+import pytest
+
+from nos.common import tqdm
+from nos.logging import logger
+from nos.models.yolox import YOLOX
+from nos.test.utils import NOS_TEST_IMAGE, PyTestGroup
+
+
+env = os.environ.get("NOS_ENV", os.getenv("CONDA_DEFAULT_ENV", "base_gpu"))
+logger.info(f"Using env: {env}")
+pytestmark = pytest.mark.skipif(
+    env not in ("nos_trt_dev", "nos_trt_runtime"),
+    reason=f"Requires nos env [nos_trt_dev, nos_trt_runtime], but using {env}",
+)
+
+
+# @pytest.mark.parametrize("precision", [torch.float32, torch.float16])
+@pytest.mark.parametrize("shape", [(640, 480), (1280, 960)])
+@pytest.mark.parametrize("model_name", list(YOLOX.configs.keys()))
+@pytest.mark.benchmark(group=PyTestGroup.MODEL_COMPILATION)
+def test_yolox_torchtrt_compilation(model_name, shape):
+    """Test and benchmark compilation of YOLOX with TorchTRT."""
+    from PIL import Image
+
+    from nos.models.yolox import YOLOXTensorRT
+
+    det = YOLOXTensorRT(model_name=model_name)
+    img1 = Image.open(NOS_TEST_IMAGE)
+    img1 = img1.resize(shape)
+
+    # First run will trigger a compilation (if not already cached)
+    predictions = det([img1])
+    assert "bboxes" in predictions
+    assert "scores" in predictions
+    assert "labels" in predictions
+    assert len(predictions["bboxes"]) == len(predictions["scores"]) == len(predictions["labels"])
+
+    # Attempt running with a different image size
+    with pytest.raises(Exception):
+        img2 = img1.resize((320, 240))
+        predictions = det([img2])
+
+    # Subsequent runs will use the cached compilation
+    logger.debug("Warming up (5s) ...")
+    for _ in tqdm(duration=5.0, disable=True):
+        predictions = det([img1])
+    logger.debug("Running benchmark (20s) ...")
+    for _ in tqdm(duration=20.0, desc=f"torch-trt | {model_name}"):
+        predictions = det([img1])


### PR DESCRIPTION
## Summary

 - added main yolox compilation + benchmark test for all yolox
 - some yolox models cannot compile just yet due to errors in accuracy (even in fp32)
 - minor typo fixes to sdv2 compilation workflow

 Validate the compilation + benchmark workflow via:
 ```bash
 make docker-test-trt DOCKER_CMD='pytest -sv tests/compilers/test_torchtrt_yolox_compilation.py -m benchmark'
 ```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
