### PR TITLE
Pull server docker image on `nos.init` with optional arg

### DIFF
--- a/nos/client/grpc.py
+++ b/nos/client/grpc.py
@@ -328,4 +328,8 @@ class InferenceModule:
             response = loads(response.response_bytes)
             return response
         except Exception as e:
-            raise NosClientException(f"Failed to run model {self.model_name} ({e})")
+            import traceback
+
+            raise NosClientException(
+                f"""Failed to run model {self.model_name} ({e})""" f"""\nTraceback\n""" f"""{traceback.format_exc()}"""
+            )

--- a/nos/executors/ray.py
+++ b/nos/executors/ray.py
@@ -95,7 +95,6 @@ class RayExecutor:
                     ray.init(
                         address="auto",
                         namespace=self.spec.namespace,
-                        object_store_memory=NOS_RAY_OBJECT_STORE_MEMORY,
                         ignore_reinit_error=True,
                         include_dashboard=False,
                         configure_logging=True,

--- a/nos/hub/__init__.py
+++ b/nos/hub/__init__.py
@@ -22,6 +22,8 @@ class Hub:
         """
         if cls._instance is None:
             cls._instance = cls()
+            # Register models / Populate the registry
+            import nos.models  # noqa: F401, E402
         return cls._instance
 
     @classmethod
@@ -99,6 +101,3 @@ list = Hub.list
 load = Hub.load
 register = Hub.register
 load_spec = Hub.load_spec
-
-# Register models / Populate the registry
-import nos.models  # noqa: F401, E402

--- a/nos/models/__init__.py
+++ b/nos/models/__init__.py
@@ -1,5 +1,3 @@
-import torch
-
 from nos import hub
 
 from .clip import CLIP  # noqa: F401

--- a/nos/server/runtime.py
+++ b/nos/server/runtime.py
@@ -9,15 +9,16 @@ from nos.constants import DEFAULT_GRPC_PORT  # noqa F401
 from nos.logging import LOGGING_LEVEL, logger
 from nos.protoc import import_module
 from nos.server.docker import DockerRuntime
+from nos.version import __version__
 
 
 nos_service_pb2 = import_module("nos_service_pb2")
 nos_service_pb2_grpc = import_module("nos_service_pb2_grpc")
 
 
-NOS_DOCKER_IMAGE_CPU = "autonomi/nos:latest-cpu"
-NOS_DOCKER_IMAGE_GPU = "autonomi/nos:latest-gpu"
-NOS_DOCKER_IMAGE_TRT_RUNTIME = "autonomi/nos:latest-trt-runtime"
+NOS_DOCKER_IMAGE_CPU = f"autonomi/nos:{__version__}-cpu"
+NOS_DOCKER_IMAGE_GPU = f"autonomi/nos:{__version__}-gpu"
+NOS_DOCKER_IMAGE_TRT_RUNTIME = f"autonomi/nos:{__version__}-trt-runtime"
 
 NOS_INFERENCE_SERVICE_CONTAINER_NAME = "nos-inference-service"
 NOS_INFERENCE_SERVICE_CMD = "nos-grpc-server"

--- a/nos/test/utils.py
+++ b/nos/test/utils.py
@@ -66,3 +66,22 @@ def skip_all_unless_nos_env(nos_env: str = None):
 
     env = os.environ.get("NOS_ENV", os.getenv("CONDA_DEFAULT_ENV", "base_gpu"))
     return pytest.mark.skipif(env != nos_env, reason=f"Requires nos env {nos_env}, but using {env}")
+
+
+def get_benchmark_video() -> str:
+    """Download a benchmark video from URL to local file."""
+    import requests
+
+    from nos.constants import NOS_CACHE_DIR
+
+    URL = "https://zackakil.github.io/video-intelligence-api-visualiser/assets/test_video.mp4"
+
+    # Download video from URL to local file
+    tmp_videos_dir = NOS_CACHE_DIR / "test_data" / "videos"
+    tmp_videos_dir.mkdir(parents=True, exist_ok=True)
+    tmp_video_filename = tmp_videos_dir / "test_video.mp4"
+    if not tmp_video_filename.exists():
+        with open(str(tmp_video_filename), "wb") as f:
+            f.write(requests.get(URL).content)
+        assert tmp_video_filename.exists()
+    return str(tmp_video_filename)

--- a/tests/client/grpc/test_grpc_client_e2e.py
+++ b/tests/client/grpc/test_grpc_client_e2e.py
@@ -11,11 +11,11 @@ import pytest
 from PIL import Image
 from tqdm import tqdm
 
+from nos.common import ModelSpec, TaskType  # noqa: E402
+from nos.test.utils import NOS_TEST_IMAGE
+
 
 pytestmark = pytest.mark.client
-
-from nos.common import ModelSpec, TaskType  # noqa: E402
-from nos.test.utils import NOS_TEST_IMAGE  # noqa: E402
 
 
 @pytest.mark.client
@@ -97,7 +97,7 @@ def test_e2e_grpc_client_and_gpu_server(grpc_client_with_gpu_backend):  # noqa: 
         assert "bboxes" in response
 
     # TXT2IMG
-    task, model_name = TaskType.IMAGE_GENERATION, "stabilityai/stable-diffusion-2"
+    task, model_name = TaskType.IMAGE_GENERATION, "stabilityai/stable-diffusion-2-1"
     model = client.Module(task=task, model_name=model_name)
     assert model is not None
     assert model.GetModelInfo() is not None
@@ -107,7 +107,6 @@ def test_e2e_grpc_client_and_gpu_server(grpc_client_with_gpu_backend):  # noqa: 
         assert "images" in response
 
 
-@pytest.mark.skip(reason="CPU backend is not ready yet")
 @pytest.mark.client
 def test_e2e_grpc_client_and_cpu_server(grpc_client_with_cpu_backend):  # noqa: F811
     """Test the gRPC client with CPU docker runtime initialized.
@@ -184,9 +183,10 @@ def test_e2e_grpc_client_and_cpu_server(grpc_client_with_cpu_backend):  # noqa: 
         assert "scores" in response
 
     # TXT2IMG
-    task, model_name = TaskType.IMAGE_GENERATION, "stabilityai/stable-diffusion-2"
-    model = client.Module(task=task, model_name=model_name)
-    assert model is not None
-    assert model.GetModelInfo() is not None
-    for _ in tqdm(range(1), desc=f"Test [task={task}, model_name={model_name}]"):
-        response = model(prompts=["a cat dancing on the grass."], width=512, height=512, num_images=1)
+    if False:
+        task, model_name = TaskType.IMAGE_GENERATION, "runwayml/stable-diffusion-v1-5"
+        model = client.Module(task=task, model_name=model_name)
+        assert model is not None
+        assert model.GetModelInfo() is not None
+        for _ in tqdm(range(1), desc=f"Test [task={task}, model_name={model_name}]"):
+            response = model(prompts=["a cat dancing on the grass."], width=512, height=512, num_images=1)

--- a/tests/client/test_client_integration.py
+++ b/tests/client/test_client_integration.py
@@ -1,16 +1,20 @@
 import pytest
 
+import nos
+from nos.client import InferenceClient
+from nos.server.runtime import InferenceServiceRuntime
+from nos.test.utils import PyTestGroup, get_benchmark_video
+
+
+GRPC_PORT = 50055
+
 
 @pytest.mark.client
 @pytest.mark.parametrize("runtime", ["cpu", "gpu", "auto"])
 def test_nos_init(runtime):  # noqa: F811
     """Test the NOS server daemon initialization."""
-    import nos
-    from nos.client import InferenceClient
-    from nos.server.runtime import InferenceServiceRuntime
 
     # Initialize the server
-    GRPC_PORT = 50055
     container = nos.init(runtime=runtime, port=GRPC_PORT, utilization=0.5)
     assert container is not None
     assert container.id is not None
@@ -26,6 +30,70 @@ def test_nos_init(runtime):  # noqa: F811
     # Test re-initializing the server
     container_ = nos.init(runtime=runtime, port=GRPC_PORT, utilization=0.5)
     assert container_.id == container.id
+
+    # Shutdown the server
+    nos.shutdown()
+    containers = InferenceServiceRuntime.list()
+    assert len(containers) == 0
+
+
+@pytest.mark.client
+@pytest.mark.benchmark(group=PyTestGroup.INTEGRATION)
+@pytest.mark.parametrize("runtime", ["gpu"])
+def test_nos_object_detection_benchmark(runtime):  # noqa: F811
+    """Test the NOS server daemon initialization."""
+    from itertools import islice
+
+    import cv2
+
+    from nos.common import TaskType, tqdm
+    from nos.common.io import VideoReader
+    from nos.logging import logger
+
+    # Initialize the server
+    container = nos.init(runtime=runtime, port=GRPC_PORT, utilization=0.8)
+    assert container is not None
+    assert container.id is not None
+    containers = InferenceServiceRuntime.list()
+    assert len(containers) == 1
+
+    # Test waiting for server to start
+    # This call should be instantaneous as the server is already ready for the test
+    client = InferenceClient(f"[::]:{GRPC_PORT}")
+    assert client.WaitForServer(timeout=180, retry_interval=5)
+    assert client.IsHealthy()
+
+    # Load video for inference
+    NOS_TEST_VIDEO = get_benchmark_video()
+    video = VideoReader(NOS_TEST_VIDEO)
+    assert len(video) > 0
+    iterations = 30 if runtime == "cpu" else min(500, len(video))
+
+    # TXT2IMG
+    if runtime == "gpu":
+        task, model_name = TaskType.IMAGE_GENERATION, "runwayml/stable-diffusion-v1-5"
+        model = client.Module(task=task, model_name=model_name)
+        assert model is not None
+        assert model.GetModelInfo() is not None
+        for _ in tqdm(range(1), desc=f"Test [task={task}, model_name={model_name}]"):
+            model(prompts=["a cat dancing on the grass."], width=512, height=512, num_images=1)
+
+    # Run object detection over the full video
+    logger.info("Running object detection over the full video...")
+    video.reset()
+    det2d = client.Module(task=TaskType.OBJECT_DETECTION_2D, model_name="yolox/medium")
+    for img in tqdm(islice(video, 0, iterations)):
+        img = cv2.resize(img, (640, 480))
+        predictions = det2d(images=[img])
+        assert predictions is not None
+
+    logger.info("Running CLIP over the full video...")
+    video.reset()
+    clip = client.Module(task=TaskType.IMAGE_EMBEDDING, model_name="openai/clip")
+    for img in tqdm(islice(video, 0, iterations)):
+        img = cv2.resize(img, (224, 224))
+        embeddings = clip(images=[img])
+        assert embeddings is not None
 
     # Shutdown the server
     nos.shutdown()

--- a/tests/models/test_stable_diffusion.py
+++ b/tests/models/test_stable_diffusion.py
@@ -17,7 +17,7 @@ def model():
 
 
 @pytest.mark.benchmark(group=PyTestGroup.HUB)
-def test_stable_diffusion(model):
+def test_stable_diffusion_predict(model):
     """Use StableDiffusion to generate an image from a text prompt.
 
     Note: This test should be able to run with CPU or GPU.


### PR DESCRIPTION
 - remove `torch` dependency from `nos.models`
 - `import nos.models` only on singleton init `Hub.get()`
 - use versioned docker runtime images instead of `latest` tag variants
 - new client integration test with longer benchmark videos

<!-- Thank you for your contribution! Please review https://github.com/autonomi-ai/nos/blob/main/docs/CONTRIBUTING.md before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Summary

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [x] Benchmark tests (when contributing new models)
   - [x] GPU/HW tests
