### PR TITLE
API updates to `nos.init` with log-level passthrough

### DIFF
--- a/nos/server/__init__.py
+++ b/nos/server/__init__.py
@@ -1,3 +1,9 @@
+import logging
+import math
+from typing import Optional
+
+import psutil
+
 import docker
 from nos.constants import DEFAULT_GRPC_PORT
 
@@ -7,6 +13,8 @@ def init(
     port: int = DEFAULT_GRPC_PORT,
     utilization: float = 0.8,
     pull: bool = True,
+    logging_level: int = logging.INFO,
+    tag: Optional[str] = None,
 ) -> docker.models.containers.Container:
     """Initialize the inference server.
 
@@ -16,14 +24,32 @@ def init(
         port (int, optional): The port to use for the inference server. Defaults to DEFAULT_GRPC_PORT.
         utilization (float, optional): The target cpu/memory utilization of inference server. Defaults to 0.8.
         pull (bool, optional): Pull the docker image before starting the inference server. Defaults to True.
+        logging_level (int, optional): The logging level to use for the inference server. Defaults to logging.INFO.
+        tag (str, optional): The tag of the docker image to use ("latest"). Defaults to None, where the
+            appropriate version is used.
     """
-    import math
-
-    import psutil
-
-    from nos.common.system import get_system_info, has_docker, has_gpu
+    from nos.common.system import has_docker, has_gpu
     from nos.logging import logger
     from nos.server.runtime import DockerRuntime, InferenceServiceRuntime
+    from nos.version import __version__
+
+    # Check arguments
+    available_runtimes = list(InferenceServiceRuntime.configs.keys()) + ["auto"]
+    if runtime not in available_runtimes:
+        raise ValueError(f"Invalid inference service runtime: {runtime}, available: {available_runtimes}")
+
+    if utilization <= 0.25 or utilization > 1:
+        raise ValueError(f"Invalid utilization: {utilization}, must be in (0.25, 1].")
+
+    if logging_level not in (logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL):
+        raise ValueError(f"Invalid logging level: {logging_level}")
+
+    if tag is None:
+        tag = __version__
+    else:
+        if not isinstance(tag, str):
+            raise ValueError(f"Invalid tag: {tag}, must be a string.")
+        raise NotImplementedError("Custom tags are not yet supported.")
 
     _MIN_NUM_CPUS = 4
     _MIN_MEM_GB = 6
@@ -53,6 +79,10 @@ def init(
     # Check system requirements
     _check_system_requirements()
 
+    # Determine runtime from system
+    if runtime == "auto":
+        runtime = "gpu" if has_gpu() else "cpu"
+
     # Check if inference server is already running
     containers = InferenceServiceRuntime.list()
     if len(containers) > 0:
@@ -62,15 +92,6 @@ def init(
         (container,) = containers
         logger.warning(f"Inference server already running (name={container.name}, id={container.id[:12]}).")
         return container
-
-    # Determine runtime from system
-    if runtime == "auto":
-        runtime = "gpu" if has_gpu() else "cpu"
-    else:
-        if runtime not in InferenceServiceRuntime.configs:
-            raise ValueError(
-                f"Invalid inference service runtime: {runtime}, available: {list(InferenceServiceRuntime.configs.keys())}"
-            )
 
     # Pull docker image (if necessary)
     if pull:
@@ -98,6 +119,9 @@ def init(
         mem_limit=f"{mem_limit}g",
         shm_size=f"{_MIN_SHMEM_GB}g",
         ports={f"{DEFAULT_GRPC_PORT}/tcp": port},
+        environment={
+            "NOS_LOGGING_LEVEL": logging.getLevelName(logging_level),
+        },
     )
     logger.info(f"Inference service started: [name={runtime.cfg.name}, runtime={runtime}, id={container.id[:12]}]")
     return container
@@ -157,6 +181,6 @@ def _pull_image(image: str, quiet: bool = False, platform: str = None) -> str:
                     status.update("[bold white]" + f"{status_str}\n\t" + "\n\t".join(status_q) + "[/bold white]")
             proc.wait()
             logger.info(f"Pulled new server image: {image}")
-        except (docker.errors.APIError, docker.errors.DockerException) as exc:
+        except Exception as exc:
             logger.error(f"Failed to pull image: {image}, exiting early: {exc}")
             raise Exception(f"Failed to pull image: {image}, please mnaully pull image via `docker pull {image}`")

--- a/tests/server/test_server_utils.py
+++ b/tests/server/test_server_utils.py
@@ -1,0 +1,55 @@
+import pytest
+
+import nos
+from nos.server.runtime import InferenceServiceRuntime
+
+
+def test_nos_init():
+    """Test the NOS server daemon initialization.
+
+    See tests/client/test_client_integration.py for the end-to-end integration with client.
+    """
+
+    # Initialize the server
+    container_1 = nos.init()
+    assert container_1 is not None
+    container_2 = nos.init()
+    assert container_2 is not None
+    assert container_1.id == container_2.id
+
+    containers = InferenceServiceRuntime.list()
+    assert len(containers) == 1
+
+    # Shutdown the server
+    nos.shutdown()
+
+    containers = InferenceServiceRuntime.list()
+    assert len(containers) == 0
+
+    # Shutdown the server again (should raise an error)
+    with pytest.raises(RuntimeError):
+        nos.shutdown()
+
+
+def test_nos_init_variants():
+    """Test the NOS server daemon initialization variants."""
+    import logging
+
+    with pytest.raises(ValueError):
+        nos.init(runtime="invalid")
+
+    for utilization in [-1, 0.0, 1.1]:
+        with pytest.raises(ValueError):
+            nos.init(utilization=utilization)
+
+    with pytest.raises(ValueError):
+        nos.init(logging_level="invalid")
+
+    with pytest.raises(ValueError):
+        nos.init(tag=0)
+
+    with pytest.raises(NotImplementedError):
+        nos.init(tag="latest")
+
+    nos.init(runtime="cpu", utilization=0.5, logging_level=logging.INFO)
+    nos.shutdown()


### PR DESCRIPTION
 - added tests for `nos.init()` server bringup

<!-- Thank you for your contribution! Please review https://github.com/autonomi-ai/nos/blob/main/docs/CONTRIBUTING.md before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Summary

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
