### PR TITLE
NOS profiler with notebook report

### DIFF
--- a/.nos/profile/nos-profile--0-0-6--20230711--nvidia-geforce-rtx-4090.json
+++ b/.nos/profile/nos-profile--0-0-6--20230711--nvidia-geforce-rtx-4090.json
@@ -1,0 +1,10850 @@
+{
+    "date": "2023-07-11 22:06:19",
+    "nos_version": "0.0.6",
+    "sysinfo": {
+        "system": {
+            "system": "Linux",
+            "release": "5.19.0-41-generic",
+            "version": "#42~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue Apr 18 17:40:00 UTC 2",
+            "machine": "x86_64",
+            "architecture": [
+                "64bit",
+                "ELF"
+            ],
+            "processor": "x86_64",
+            "python_implementation": "CPython"
+        },
+        "cpu": {
+            "model": "AMD Ryzen Threadripper 3970X 32-Core Processor",
+            "architecture": "x86_64",
+            "cores": {
+                "physical": 32,
+                "total": 64
+            },
+            "frequency": 3300.0,
+            "frequency_str": "3.30 GHz"
+        },
+        "memory": {
+            "total": 134905909248,
+            "used": 26670395392,
+            "available": 75476721664
+        },
+        "torch": {
+            "version": "2.0.1"
+        },
+        "docker": {
+            "version": "Docker version 24.0.0, build 98fdcd7",
+            "sdk_version": "6.1.0",
+            "compose_version": "Docker Compose version v2.17.3"
+        },
+        "gpu": {
+            "cuda_version": "11.7",
+            "cudnn_version": 8500,
+            "device_count": 1,
+            "devices": [
+                {
+                    "device_id": 0,
+                    "device_name": "NVIDIA GeForce RTX 4090",
+                    "device_capability": "8.9",
+                    "total_memory": 25393692672,
+                    "total_memory_str": "23.65 GB",
+                    "multi_processor_count": 128
+                }
+            ],
+            "driver_version": "530.41.03"
+        }
+    },
+    "records": [
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 910819328,
+                "init::memory_cpu::pre": 48349179904,
+                "init::memory_gpu::post": 1571422208,
+                "init::memory_cpu::post": 49376686080,
+                "forward::memory_gpu::pre": 1571422208,
+                "forward::memory_cpu::pre": 49389588480,
+                "forward::memory_gpu::post": 2229927936,
+                "forward::memory_cpu::post": 50471333888,
+                "forward_warmup::execution": {
+                    "num_iterations": 734,
+                    "total_ms": 5005.406379699707,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 26
+                },
+                "forward::execution": {
+                    "num_iterations": 1489,
+                    "total_ms": 10002.034187316895,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 26
+                },
+                "cleanup::memory_gpu::pre": 2229927936,
+                "cleanup::memory_cpu::pre": 50503561216,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 50505199616,
+                "wrap::memory_gpu::pre": 910819328,
+                "wrap::memory_cpu::pre": 48349179904,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 50505199616
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 50495393792,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51325898752,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51325898752,
+                "forward::memory_gpu::post": 2229927936,
+                "forward::memory_cpu::post": 51325898752,
+                "forward_warmup::execution": {
+                    "num_iterations": 495,
+                    "total_ms": 5010.067462921143,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 18
+                },
+                "forward::execution": {
+                    "num_iterations": 998,
+                    "total_ms": 10008.319854736328,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 18
+                },
+                "cleanup::memory_gpu::pre": 2229927936,
+                "cleanup::memory_cpu::pre": 51326291968,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51335254016,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 50495393792,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51335254016
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51326480384,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51539144704,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51539144704,
+                "forward::memory_gpu::post": 2229927936,
+                "forward::memory_cpu::post": 51539144704,
+                "forward_warmup::execution": {
+                    "num_iterations": 634,
+                    "total_ms": 5004.29630279541,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 31
+                },
+                "forward::execution": {
+                    "num_iterations": 1247,
+                    "total_ms": 10005.781650543213,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 32
+                },
+                "cleanup::memory_gpu::pre": 2229927936,
+                "cleanup::memory_cpu::pre": 51536584704,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51536633856,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51326480384,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51536633856
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51529408512,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51577307136,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51577307136,
+                "forward::memory_gpu::post": 2229927936,
+                "forward::memory_cpu::post": 51577274368,
+                "forward_warmup::execution": {
+                    "num_iterations": 326,
+                    "total_ms": 5005.681037902832,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 17
+                },
+                "forward::execution": {
+                    "num_iterations": 654,
+                    "total_ms": 10004.933834075928,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 17
+                },
+                "cleanup::memory_gpu::pre": 2229927936,
+                "cleanup::memory_cpu::pre": 51549470720,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51549470720,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51529408512,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51549470720
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51544305664,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51646685184,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51646152704,
+                "forward::memory_gpu::post": 2255093760,
+                "forward::memory_cpu::post": 51646152704,
+                "forward_warmup::execution": {
+                    "num_iterations": 438,
+                    "total_ms": 5009.241342544556,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 28
+                },
+                "forward::execution": {
+                    "num_iterations": 878,
+                    "total_ms": 10007.999181747437,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 27
+                },
+                "cleanup::memory_gpu::pre": 2255093760,
+                "cleanup::memory_cpu::pre": 51670265856,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51670523904,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51544305664,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51670523904
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51663298560,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51683143680,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51683143680,
+                "forward::memory_gpu::post": 2255093760,
+                "forward::memory_cpu::post": 51683143680,
+                "forward_warmup::execution": {
+                    "num_iterations": 200,
+                    "total_ms": 5017.844676971436,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 12
+                },
+                "forward::execution": {
+                    "num_iterations": 402,
+                    "total_ms": 10011.19589805603,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 14
+                },
+                "cleanup::memory_gpu::pre": 2255093760,
+                "cleanup::memory_cpu::pre": 51661352960,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51661156352,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51663298560,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51661156352
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51655995392,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51670638592,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51670638592,
+                "forward::memory_gpu::post": 2250899456,
+                "forward::memory_cpu::post": 51670638592,
+                "forward_warmup::execution": {
+                    "num_iterations": 284,
+                    "total_ms": 5010.383129119873,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 23
+                },
+                "forward::execution": {
+                    "num_iterations": 570,
+                    "total_ms": 10008.147954940796,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 25
+                },
+                "cleanup::memory_gpu::pre": 2250899456,
+                "cleanup::memory_cpu::pre": 51682623488,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51695255552,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51655995392,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51695255552
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51689578496,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51635888128,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51635888128,
+                "forward::memory_gpu::post": 2250899456,
+                "forward::memory_cpu::post": 51635888128,
+                "forward_warmup::execution": {
+                    "num_iterations": 112,
+                    "total_ms": 5002.367734909058,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 11
+                },
+                "forward::execution": {
+                    "num_iterations": 225,
+                    "total_ms": 10020.052433013916,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 10
+                },
+                "cleanup::memory_gpu::pre": 2250899456,
+                "cleanup::memory_cpu::pre": 51647426560,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51648397312,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51689578496,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51648397312
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51641688064,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51671121920,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51671638016,
+                "forward::memory_gpu::post": 2290745344,
+                "forward::memory_cpu::post": 51671638016,
+                "forward_warmup::execution": {
+                    "num_iterations": 172,
+                    "total_ms": 5012.213468551636,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 20
+                },
+                "forward::execution": {
+                    "num_iterations": 342,
+                    "total_ms": 10006.274938583374,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 22
+                },
+                "cleanup::memory_gpu::pre": 2290745344,
+                "cleanup::memory_cpu::pre": 51654438912,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51654438912,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51641688064,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51654438912
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51648761856,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51653115904,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51653115904,
+                "forward::memory_gpu::post": 2290745344,
+                "forward::memory_cpu::post": 51656212480,
+                "forward_warmup::execution": {
+                    "num_iterations": 61,
+                    "total_ms": 5017.251968383789,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 6
+                },
+                "forward::execution": {
+                    "num_iterations": 121,
+                    "total_ms": 10027.431726455688,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 6
+                },
+                "cleanup::memory_gpu::pre": 2290745344,
+                "cleanup::memory_cpu::pre": 51691171840,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51667935232,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51648761856,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51667935232
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51662774272,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51670405120,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51670216704,
+                "forward::memory_gpu::post": 2332688384,
+                "forward::memory_cpu::post": 51667484672,
+                "forward_warmup::execution": {
+                    "num_iterations": 91,
+                    "total_ms": 5001.543760299683,
+                    "cpu_utilization": 51.7,
+                    "gpu_utilization": 16
+                },
+                "forward::execution": {
+                    "num_iterations": 182,
+                    "total_ms": 10034.939289093018,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 21
+                },
+                "cleanup::memory_gpu::pre": 2332688384,
+                "cleanup::memory_cpu::pre": 51654512640,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51674587136,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51662774272,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51674587136
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51668910080,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51675721728,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51675721728,
+                "forward::memory_gpu::post": 2332688384,
+                "forward::memory_cpu::post": 51676491776,
+                "forward_warmup::execution": {
+                    "num_iterations": 32,
+                    "total_ms": 5138.136386871338,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 5
+                },
+                "forward::execution": {
+                    "num_iterations": 62,
+                    "total_ms": 10042.052745819092,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 5
+                },
+                "cleanup::memory_gpu::pre": 2332688384,
+                "cleanup::memory_cpu::pre": 51655172096,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51658756096,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51668910080,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51658756096
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51654111232,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51664064512,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51677978624,
+                "forward::memory_gpu::post": 2471100416,
+                "forward::memory_cpu::post": 51677978624,
+                "forward_warmup::execution": {
+                    "num_iterations": 46,
+                    "total_ms": 5021.625995635986,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 15
+                },
+                "forward::execution": {
+                    "num_iterations": 92,
+                    "total_ms": 10056.775093078613,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 22
+                },
+                "cleanup::memory_gpu::pre": 2471100416,
+                "cleanup::memory_cpu::pre": 51650703360,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51650703360,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51654111232,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51650703360
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51645026304,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51652259840,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51662766080,
+                "forward::memory_gpu::post": 2471100416,
+                "forward::memory_cpu::post": 51676631040,
+                "forward_warmup::execution": {
+                    "num_iterations": 17,
+                    "total_ms": 5263.876676559448,
+                    "cpu_utilization": 31.2,
+                    "gpu_utilization": 0
+                },
+                "forward::execution": {
+                    "num_iterations": 33,
+                    "total_ms": 10147.120475769043,
+                    "cpu_utilization": 31.5,
+                    "gpu_utilization": 0
+                },
+                "cleanup::memory_gpu::pre": 2471100416,
+                "cleanup::memory_cpu::pre": 51679850496,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51680096256,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51645026304,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51680096256
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51673903104,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51658104832,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51662970880,
+                "forward::memory_gpu::post": 2708078592,
+                "forward::memory_cpu::post": 51679703040,
+                "forward_warmup::execution": {
+                    "num_iterations": 24,
+                    "total_ms": 5078.978776931763,
+                    "cpu_utilization": 44.9,
+                    "gpu_utilization": 22
+                },
+                "forward::execution": {
+                    "num_iterations": 47,
+                    "total_ms": 10008.533000946045,
+                    "cpu_utilization": 44.6,
+                    "gpu_utilization": 22
+                },
+                "cleanup::memory_gpu::pre": 2708078592,
+                "cleanup::memory_cpu::pre": 51656937472,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51656904704,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51673903104,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51656904704
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51653292032,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51658620928,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51681808384,
+                "forward::memory_gpu::post": 2708078592,
+                "forward::memory_cpu::post": 51659272192,
+                "forward_warmup::execution": {
+                    "num_iterations": 9,
+                    "total_ms": 5563.20858001709,
+                    "cpu_utilization": 17.6,
+                    "gpu_utilization": 0
+                },
+                "forward::execution": {
+                    "num_iterations": 17,
+                    "total_ms": 10543.08557510376,
+                    "cpu_utilization": 17.6,
+                    "gpu_utilization": 0
+                },
+                "cleanup::memory_gpu::pre": 2708078592,
+                "cleanup::memory_cpu::pre": 51664232448,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51668180992,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51653292032,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51668180992
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51665084416,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51675181056,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51665842176,
+                "forward::memory_gpu::post": 3165257728,
+                "forward::memory_cpu::post": 51689582592,
+                "forward_warmup::execution": {
+                    "num_iterations": 14,
+                    "total_ms": 5343.269824981689,
+                    "cpu_utilization": 26.9,
+                    "gpu_utilization": 4
+                },
+                "forward::execution": {
+                    "num_iterations": 27,
+                    "total_ms": 10255.774021148682,
+                    "cpu_utilization": 27.0,
+                    "gpu_utilization": 15
+                },
+                "cleanup::memory_gpu::pre": 3165257728,
+                "cleanup::memory_cpu::pre": 51667263488,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51667243008,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51665084416,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51667243008
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 256,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51663114240,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51667632128,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51667214336,
+                "forward::memory_gpu::post": 3165257728,
+                "forward::memory_cpu::post": 51666452480,
+                "forward_warmup::execution": {
+                    "num_iterations": 5,
+                    "total_ms": 6009.337425231934,
+                    "cpu_utilization": 10.8,
+                    "gpu_utilization": 0
+                },
+                "forward::execution": {
+                    "num_iterations": 9,
+                    "total_ms": 10856.020212173462,
+                    "cpu_utilization": 10.6,
+                    "gpu_utilization": 25
+                },
+                "cleanup::memory_gpu::pre": 3165257728,
+                "cleanup::memory_cpu::pre": 51662884864,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51662884864,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51663114240,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51662884864
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 256,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51659788288,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51665891328,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51684556800,
+                "forward::memory_gpu::post": 4194959360,
+                "forward::memory_cpu::post": 51649519616,
+                "forward_warmup::execution": {
+                    "num_iterations": 7,
+                    "total_ms": 5247.073173522949,
+                    "cpu_utilization": 15.7,
+                    "gpu_utilization": 58
+                },
+                "forward::execution": {
+                    "num_iterations": 14,
+                    "total_ms": 10465.503692626953,
+                    "cpu_utilization": 15.9,
+                    "gpu_utilization": 22
+                },
+                "cleanup::memory_gpu::pre": 4194959360,
+                "cleanup::memory_cpu::pre": 51645263872,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51645038592,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51659788288,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51645038592
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 512,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51642458112,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51661467648,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51662147584,
+                "forward::memory_gpu::post": 4194959360,
+                "forward::memory_cpu::post": 51672403968,
+                "forward_warmup::execution": {
+                    "num_iterations": 3,
+                    "total_ms": 7328.227281570435,
+                    "cpu_utilization": 6.9,
+                    "gpu_utilization": 75
+                },
+                "forward::execution": {
+                    "num_iterations": 5,
+                    "total_ms": 12237.015962600708,
+                    "cpu_utilization": 7.1,
+                    "gpu_utilization": 54
+                },
+                "cleanup::memory_gpu::pre": 4194959360,
+                "cleanup::memory_cpu::pre": 51667963904,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51667488768,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51642458112,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51667488768
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 512,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51664908288,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51652317184,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51653074944,
+                "forward::memory_gpu::post": 6145310720,
+                "forward::memory_cpu::post": 51673948160,
+                "forward_warmup::execution": {
+                    "num_iterations": 4,
+                    "total_ms": 6431.308269500732,
+                    "cpu_utilization": 9.6,
+                    "gpu_utilization": 75
+                },
+                "forward::execution": {
+                    "num_iterations": 7,
+                    "total_ms": 11261.387586593628,
+                    "cpu_utilization": 9.5,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 6145310720,
+                "cleanup::memory_cpu::pre": 51659448320,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51662520320,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51664908288,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51662520320
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1024,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51661488128,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51660120064,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51670441984,
+                "forward::memory_gpu::post": 6145310720,
+                "forward::memory_cpu::post": 51717517312,
+                "forward_warmup::execution": {
+                    "num_iterations": 1,
+                    "total_ms": 5202.754497528076,
+                    "cpu_utilization": 6.1,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 2,
+                    "total_ms": 10413.218975067139,
+                    "cpu_utilization": 5.0,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 6145310720,
+                "cleanup::memory_cpu::pre": 51714633728,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51714633728,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51661488128,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51714633728
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1024,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51712569344,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51729870848,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51729870848,
+                "forward::memory_gpu::post": 2229927936,
+                "forward::memory_cpu::post": 51729870848,
+                "forward_warmup::execution": {
+                    "num_iterations": 746,
+                    "total_ms": 5002.744436264038,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 26
+                },
+                "forward::execution": {
+                    "num_iterations": 1471,
+                    "total_ms": 10005.677223205566,
+                    "cpu_utilization": 52.4,
+                    "gpu_utilization": 27
+                },
+                "cleanup::memory_gpu::pre": 2229927936,
+                "cleanup::memory_cpu::pre": 51708141568,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51708141568,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51712569344,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51708141568
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51705561088,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51706605568,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51706605568,
+                "forward::memory_gpu::post": 2229927936,
+                "forward::memory_cpu::post": 51706605568,
+                "forward_warmup::execution": {
+                    "num_iterations": 498,
+                    "total_ms": 5006.317853927612,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 18
+                },
+                "forward::execution": {
+                    "num_iterations": 1000,
+                    "total_ms": 10010.779619216919,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 18
+                },
+                "cleanup::memory_gpu::pre": 2229927936,
+                "cleanup::memory_cpu::pre": 51711995904,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51735920640,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51705561088,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51735920640
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51731230720,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51692183552,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51692183552,
+                "forward::memory_gpu::post": 2229927936,
+                "forward::memory_cpu::post": 51692183552,
+                "forward_warmup::execution": {
+                    "num_iterations": 598,
+                    "total_ms": 5003.352165222168,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 31
+                },
+                "forward::execution": {
+                    "num_iterations": 1222,
+                    "total_ms": 10006.623029708862,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 33
+                },
+                "cleanup::memory_gpu::pre": 2229927936,
+                "cleanup::memory_cpu::pre": 51695161344,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51695161344,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51731230720,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51695161344
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51693096960,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51714699264,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51714699264,
+                "forward::memory_gpu::post": 2229927936,
+                "forward::memory_cpu::post": 51714699264,
+                "forward_warmup::execution": {
+                    "num_iterations": 337,
+                    "total_ms": 5013.951539993286,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 17
+                },
+                "forward::execution": {
+                    "num_iterations": 686,
+                    "total_ms": 10010.277271270752,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 18
+                },
+                "cleanup::memory_gpu::pre": 2229927936,
+                "cleanup::memory_cpu::pre": 51706159104,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51707281408,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51693096960,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51707281408
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51705217024,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51707932672,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51707932672,
+                "forward::memory_gpu::post": 2255093760,
+                "forward::memory_cpu::post": 51707932672,
+                "forward_warmup::execution": {
+                    "num_iterations": 444,
+                    "total_ms": 5001.055717468262,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 28
+                },
+                "forward::execution": {
+                    "num_iterations": 884,
+                    "total_ms": 10003.547191619873,
+                    "cpu_utilization": 52.2,
+                    "gpu_utilization": 30
+                },
+                "cleanup::memory_gpu::pre": 2255093760,
+                "cleanup::memory_cpu::pre": 51711160320,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51729412096,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51705217024,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51729412096
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51726315520,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51703279616,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51703279616,
+                "forward::memory_gpu::post": 2255093760,
+                "forward::memory_cpu::post": 51703279616,
+                "forward_warmup::execution": {
+                    "num_iterations": 202,
+                    "total_ms": 5019.668102264404,
+                    "cpu_utilization": 51.2,
+                    "gpu_utilization": 13
+                },
+                "forward::execution": {
+                    "num_iterations": 405,
+                    "total_ms": 10023.08440208435,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 14
+                },
+                "cleanup::memory_gpu::pre": 2255093760,
+                "cleanup::memory_cpu::pre": 51704889344,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51705118720,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51726315520,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51705118720
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51704086528,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51729387520,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51730132992,
+                "forward::memory_gpu::post": 2250899456,
+                "forward::memory_cpu::post": 51730132992,
+                "forward_warmup::execution": {
+                    "num_iterations": 282,
+                    "total_ms": 5013.846874237061,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 23
+                },
+                "forward::execution": {
+                    "num_iterations": 538,
+                    "total_ms": 10002.559185028076,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 23
+                },
+                "cleanup::memory_gpu::pre": 2250899456,
+                "cleanup::memory_cpu::pre": 51697364992,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51697594368,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51704086528,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51697594368
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51695529984,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51707314176,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51711700992,
+                "forward::memory_gpu::post": 2250899456,
+                "forward::memory_cpu::post": 51720704000,
+                "forward_warmup::execution": {
+                    "num_iterations": 113,
+                    "total_ms": 5002.131938934326,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 9
+                },
+                "forward::execution": {
+                    "num_iterations": 225,
+                    "total_ms": 10011.64436340332,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 11
+                },
+                "cleanup::memory_gpu::pre": 2250899456,
+                "cleanup::memory_cpu::pre": 51723186176,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51699949568,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51695529984,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51699949568
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51697864704,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51700137984,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51700428800,
+                "forward::memory_gpu::post": 2290745344,
+                "forward::memory_cpu::post": 51700428800,
+                "forward_warmup::execution": {
+                    "num_iterations": 165,
+                    "total_ms": 5008.787155151367,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 22
+                },
+                "forward::execution": {
+                    "num_iterations": 340,
+                    "total_ms": 10011.27552986145,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 21
+                },
+                "cleanup::memory_gpu::pre": 2290745344,
+                "cleanup::memory_cpu::pre": 51705864192,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51722956800,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51697864704,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51722956800
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51721408512,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51721961472,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51721961472,
+                "forward::memory_gpu::post": 2290745344,
+                "forward::memory_cpu::post": 51699224576,
+                "forward_warmup::execution": {
+                    "num_iterations": 64,
+                    "total_ms": 5051.743507385254,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 6
+                },
+                "forward::execution": {
+                    "num_iterations": 127,
+                    "total_ms": 10016.285181045532,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 6
+                },
+                "cleanup::memory_gpu::pre": 2290745344,
+                "cleanup::memory_cpu::pre": 51689123840,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51690020864,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51721408512,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51690020864
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51688472576,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51715391488,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51715391488,
+                "forward::memory_gpu::post": 2332688384,
+                "forward::memory_cpu::post": 51715960832,
+                "forward_warmup::execution": {
+                    "num_iterations": 88,
+                    "total_ms": 5017.39764213562,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 16
+                },
+                "forward::execution": {
+                    "num_iterations": 188,
+                    "total_ms": 10030.594110488892,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 22
+                },
+                "cleanup::memory_gpu::pre": 2332688384,
+                "cleanup::memory_cpu::pre": 51699712000,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51699712000,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51688472576,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51699712000
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51698679808,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51700461568,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51700461568,
+                "forward::memory_gpu::post": 2332688384,
+                "forward::memory_cpu::post": 51722358784,
+                "forward_warmup::execution": {
+                    "num_iterations": 33,
+                    "total_ms": 5137.1095180511475,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 5
+                },
+                "forward::execution": {
+                    "num_iterations": 64,
+                    "total_ms": 10129.513502120972,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 10
+                },
+                "cleanup::memory_gpu::pre": 2332688384,
+                "cleanup::memory_cpu::pre": 51700690944,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51700690944,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51698679808,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51700690944
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51700690944,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51705073664,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51715813376,
+                "forward::memory_gpu::post": 2471100416,
+                "forward::memory_cpu::post": 51729477632,
+                "forward_warmup::execution": {
+                    "num_iterations": 46,
+                    "total_ms": 5063.78698348999,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 22
+                },
+                "forward::execution": {
+                    "num_iterations": 92,
+                    "total_ms": 10095.16716003418,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 22
+                },
+                "cleanup::memory_gpu::pre": 2471100416,
+                "cleanup::memory_cpu::pre": 51703193600,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51703963648,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51700690944,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51703963648
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51702931456,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51700928512,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51710357504,
+                "forward::memory_gpu::post": 2471100416,
+                "forward::memory_cpu::post": 51724775424,
+                "forward_warmup::execution": {
+                    "num_iterations": 17,
+                    "total_ms": 5166.862964630127,
+                    "cpu_utilization": 31.7,
+                    "gpu_utilization": 0
+                },
+                "forward::execution": {
+                    "num_iterations": 33,
+                    "total_ms": 10045.376777648926,
+                    "cpu_utilization": 31.7,
+                    "gpu_utilization": 4
+                },
+                "cleanup::memory_gpu::pre": 2471100416,
+                "cleanup::memory_cpu::pre": 51703115776,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51713015808,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51702931456,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51713015808
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51712499712,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51724853248,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51700998144,
+                "forward::memory_gpu::post": 2708078592,
+                "forward::memory_cpu::post": 51701223424,
+                "forward_warmup::execution": {
+                    "num_iterations": 25,
+                    "total_ms": 5207.422494888306,
+                    "cpu_utilization": 45.4,
+                    "gpu_utilization": 22
+                },
+                "forward::execution": {
+                    "num_iterations": 49,
+                    "total_ms": 10182.50823020935,
+                    "cpu_utilization": 45.6,
+                    "gpu_utilization": 22
+                },
+                "cleanup::memory_gpu::pre": 2708078592,
+                "cleanup::memory_cpu::pre": 51720212480,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51696386048,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51712499712,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51696386048
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51696386048,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51697528832,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51704942592,
+                "forward::memory_gpu::post": 2708078592,
+                "forward::memory_cpu::post": 51708649472,
+                "forward_warmup::execution": {
+                    "num_iterations": 9,
+                    "total_ms": 5545.214414596558,
+                    "cpu_utilization": 17.3,
+                    "gpu_utilization": 16
+                },
+                "forward::execution": {
+                    "num_iterations": 17,
+                    "total_ms": 10507.040739059448,
+                    "cpu_utilization": 17.4,
+                    "gpu_utilization": 0
+                },
+                "cleanup::memory_gpu::pre": 2708078592,
+                "cleanup::memory_cpu::pre": 51696566272,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51696566272,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51696386048,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51696566272
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51696566272,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51698065408,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51699728384,
+                "forward::memory_gpu::post": 3165257728,
+                "forward::memory_cpu::post": 51699437568,
+                "forward_warmup::execution": {
+                    "num_iterations": 14,
+                    "total_ms": 5305.802345275879,
+                    "cpu_utilization": 27.3,
+                    "gpu_utilization": 0
+                },
+                "forward::execution": {
+                    "num_iterations": 27,
+                    "total_ms": 10145.975589752197,
+                    "cpu_utilization": 27.4,
+                    "gpu_utilization": 0
+                },
+                "cleanup::memory_gpu::pre": 3165257728,
+                "cleanup::memory_cpu::pre": 51700584448,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51700625408,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51696566272,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51700625408
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 256,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51700625408,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51710971904,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51701116928,
+                "forward::memory_gpu::post": 3165257728,
+                "forward::memory_cpu::post": 51694264320,
+                "forward_warmup::execution": {
+                    "num_iterations": 5,
+                    "total_ms": 6168.465375900269,
+                    "cpu_utilization": 10.2,
+                    "gpu_utilization": 32
+                },
+                "forward::execution": {
+                    "num_iterations": 9,
+                    "total_ms": 10955.27458190918,
+                    "cpu_utilization": 10.7,
+                    "gpu_utilization": 0
+                },
+                "cleanup::memory_gpu::pre": 3165257728,
+                "cleanup::memory_cpu::pre": 51692945408,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51695894528,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51700625408,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51695894528
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 256,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51695894528,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51709304832,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51719987200,
+                "forward::memory_gpu::post": 4194959360,
+                "forward::memory_cpu::post": 51692830720,
+                "forward_warmup::execution": {
+                    "num_iterations": 7,
+                    "total_ms": 5275.810956954956,
+                    "cpu_utilization": 15.8,
+                    "gpu_utilization": 18
+                },
+                "forward::execution": {
+                    "num_iterations": 14,
+                    "total_ms": 10500.4301071167,
+                    "cpu_utilization": 15.7,
+                    "gpu_utilization": 65
+                },
+                "cleanup::memory_gpu::pre": 4194959360,
+                "cleanup::memory_cpu::pre": 51689426944,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51696095232,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51695894528,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51696095232
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 512,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51696611328,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51714473984,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51691634688,
+                "forward::memory_gpu::post": 4194959360,
+                "forward::memory_cpu::post": 51690995712,
+                "forward_warmup::execution": {
+                    "num_iterations": 2,
+                    "total_ms": 5051.5382289886475,
+                    "cpu_utilization": 6.6,
+                    "gpu_utilization": 11
+                },
+                "forward::execution": {
+                    "num_iterations": 4,
+                    "total_ms": 10103.715658187866,
+                    "cpu_utilization": 6.9,
+                    "gpu_utilization": 57
+                },
+                "cleanup::memory_gpu::pre": 4194959360,
+                "cleanup::memory_cpu::pre": 51690242048,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51714002944,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51696611328,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51714002944
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 512,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51714002944,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51702415360,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51701362688,
+                "forward::memory_gpu::post": 6145310720,
+                "forward::memory_cpu::post": 51718983680,
+                "forward_warmup::execution": {
+                    "num_iterations": 4,
+                    "total_ms": 6648.983716964722,
+                    "cpu_utilization": 9.3,
+                    "gpu_utilization": 72
+                },
+                "forward::execution": {
+                    "num_iterations": 7,
+                    "total_ms": 11660.387754440308,
+                    "cpu_utilization": 9.2,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 6145310720,
+                "cleanup::memory_cpu::pre": 51695849472,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51704610816,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51714002944,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51704610816
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1024,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-base-patch32",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51704610816,
+                "init::memory_gpu::post": 2227830784,
+                "init::memory_cpu::post": 51682775040,
+                "forward::memory_gpu::pre": 2227830784,
+                "forward::memory_cpu::pre": 51828363264,
+                "forward::memory_gpu::post": 6145310720,
+                "forward::memory_cpu::post": 51884048384,
+                "forward_warmup::execution": {
+                    "num_iterations": 1,
+                    "total_ms": 5203.449010848999,
+                    "cpu_utilization": 5.1,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 2,
+                    "total_ms": 10410.74275970459,
+                    "cpu_utilization": 5.0,
+                    "gpu_utilization": 98
+                },
+                "cleanup::memory_gpu::pre": 6145310720,
+                "cleanup::memory_cpu::pre": 51884609536,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51884838912,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51704610816,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51884838912
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1024,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51723816960,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 51680137216,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 51680137216,
+                "forward::memory_gpu::post": 3351904256,
+                "forward::memory_cpu::post": 51680137216,
+                "forward_warmup::execution": {
+                    "num_iterations": 423,
+                    "total_ms": 5007.148027420044,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 76
+                },
+                "forward::execution": {
+                    "num_iterations": 844,
+                    "total_ms": 10008.382558822632,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 76
+                },
+                "cleanup::memory_gpu::pre": 3351904256,
+                "cleanup::memory_cpu::pre": 51689091072,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51689091072,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51723816960,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51689091072
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51688058880,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 51692920832,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 51692920832,
+                "forward::memory_gpu::post": 3351904256,
+                "forward::memory_cpu::post": 51689824256,
+                "forward_warmup::execution": {
+                    "num_iterations": 337,
+                    "total_ms": 5013.797998428345,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 62
+                },
+                "forward::execution": {
+                    "num_iterations": 649,
+                    "total_ms": 10011.270523071289,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 61
+                },
+                "cleanup::memory_gpu::pre": 3351904256,
+                "cleanup::memory_cpu::pre": 51691044864,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51691044864,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51688058880,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51691044864
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51690528768,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 51714174976,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 51714174976,
+                "forward::memory_gpu::post": 3372875776,
+                "forward::memory_cpu::post": 51714174976,
+                "forward_warmup::execution": {
+                    "num_iterations": 288,
+                    "total_ms": 5015.670537948608,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 87
+                },
+                "forward::execution": {
+                    "num_iterations": 578,
+                    "total_ms": 10015.995264053345,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 83
+                },
+                "cleanup::memory_gpu::pre": 3372875776,
+                "cleanup::memory_cpu::pre": 51695120384,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51695120384,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51690528768,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51695120384
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51695120384,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 51696836608,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 51696836608,
+                "forward::memory_gpu::post": 3372875776,
+                "forward::memory_cpu::post": 51696836608,
+                "forward_warmup::execution": {
+                    "num_iterations": 200,
+                    "total_ms": 5020.5864906311035,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 61
+                },
+                "forward::execution": {
+                    "num_iterations": 399,
+                    "total_ms": 10007.025718688965,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 60
+                },
+                "cleanup::memory_gpu::pre": 3372875776,
+                "cleanup::memory_cpu::pre": 51719614464,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 51719417856,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51695120384,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 51719417856
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 51719417856,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 52642840576,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 52642840576,
+                "forward::memory_gpu::post": 3429498880,
+                "forward::memory_cpu::post": 52642680832,
+                "forward_warmup::execution": {
+                    "num_iterations": 173,
+                    "total_ms": 5027.340888977051,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 80
+                },
+                "forward::execution": {
+                    "num_iterations": 344,
+                    "total_ms": 10018.397092819214,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 80
+                },
+                "cleanup::memory_gpu::pre": 3429498880,
+                "cleanup::memory_cpu::pre": 52637048832,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 52640145408,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 51719417856,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 52640145408
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 52640129024,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 52640653312,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 52640649216,
+                "forward::memory_gpu::post": 3429498880,
+                "forward::memory_cpu::post": 52640649216,
+                "forward_warmup::execution": {
+                    "num_iterations": 116,
+                    "total_ms": 5042.803049087524,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 56
+                },
+                "forward::execution": {
+                    "num_iterations": 232,
+                    "total_ms": 10038.671493530273,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 53
+                },
+                "cleanup::memory_gpu::pre": 3429498880,
+                "cleanup::memory_cpu::pre": 52660523008,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 52637298688,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 52640129024,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 52637298688
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 52637298688,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 52640923648,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 52640145408,
+                "forward::memory_gpu::post": 3500802048,
+                "forward::memory_cpu::post": 52640063488,
+                "forward_warmup::execution": {
+                    "num_iterations": 88,
+                    "total_ms": 5042.593479156494,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 80
+                },
+                "forward::execution": {
+                    "num_iterations": 175,
+                    "total_ms": 10021.792650222778,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 76
+                },
+                "cleanup::memory_gpu::pre": 3500802048,
+                "cleanup::memory_cpu::pre": 52635652096,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 52635877376,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 52637298688,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 52635877376
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 52635877376,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 52660867072,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 52660867072,
+                "forward::memory_gpu::post": 3500802048,
+                "forward::memory_cpu::post": 52660867072,
+                "forward_warmup::execution": {
+                    "num_iterations": 61,
+                    "total_ms": 5080.469608306885,
+                    "cpu_utilization": 51.2,
+                    "gpu_utilization": 50
+                },
+                "forward::execution": {
+                    "num_iterations": 119,
+                    "total_ms": 10001.82294845581,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 47
+                },
+                "cleanup::memory_gpu::pre": 3500802048,
+                "cleanup::memory_cpu::pre": 52642701312,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 52642455552,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 52635877376,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 52642455552
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 52642455552,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 52678778880,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 52678778880,
+                "forward::memory_gpu::post": 3689545728,
+                "forward::memory_cpu::post": 52678774784,
+                "forward_warmup::execution": {
+                    "num_iterations": 44,
+                    "total_ms": 5090.619087219238,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 77
+                },
+                "forward::execution": {
+                    "num_iterations": 87,
+                    "total_ms": 10085.063934326172,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 78
+                },
+                "cleanup::memory_gpu::pre": 3689545728,
+                "cleanup::memory_cpu::pre": 52704915456,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 52682264576,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 52642455552,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 52682264576
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 52682264576,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 52683755520,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 52683755520,
+                "forward::memory_gpu::post": 3689545728,
+                "forward::memory_cpu::post": 52683640832,
+                "forward_warmup::execution": {
+                    "num_iterations": 30,
+                    "total_ms": 5059.706449508667,
+                    "cpu_utilization": 51.2,
+                    "gpu_utilization": 62
+                },
+                "forward::execution": {
+                    "num_iterations": 60,
+                    "total_ms": 10128.03864479065,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 56
+                },
+                "cleanup::memory_gpu::pre": 3689545728,
+                "cleanup::memory_cpu::pre": 52713586688,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 52714053632,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 52682264576,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 52714053632
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 52714053632,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 52684300288,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 52683784192,
+                "forward::memory_gpu::post": 4008312832,
+                "forward::memory_cpu::post": 52683636736,
+                "forward_warmup::execution": {
+                    "num_iterations": 23,
+                    "total_ms": 5003.331422805786,
+                    "cpu_utilization": 42.8,
+                    "gpu_utilization": 87
+                },
+                "forward::execution": {
+                    "num_iterations": 46,
+                    "total_ms": 10017.36044883728,
+                    "cpu_utilization": 42.7,
+                    "gpu_utilization": 79
+                },
+                "cleanup::memory_gpu::pre": 4008312832,
+                "cleanup::memory_cpu::pre": 52680179712,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 52699787264,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 52714053632,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 52699787264
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 52699787264,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 52705218560,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 52705447936,
+                "forward::memory_gpu::post": 4008312832,
+                "forward::memory_cpu::post": 52681396224,
+                "forward_warmup::execution": {
+                    "num_iterations": 16,
+                    "total_ms": 5049.450397491455,
+                    "cpu_utilization": 30.4,
+                    "gpu_utilization": 58
+                },
+                "forward::execution": {
+                    "num_iterations": 32,
+                    "total_ms": 10093.456029891968,
+                    "cpu_utilization": 30.5,
+                    "gpu_utilization": 29
+                },
+                "cleanup::memory_gpu::pre": 4008312832,
+                "cleanup::memory_cpu::pre": 52679151616,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 52699279360,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 52699787264,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 52699279360
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 52699279360,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 52702216192,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 52702216192,
+                "forward::memory_gpu::post": 4668915712,
+                "forward::memory_cpu::post": 52679249920,
+                "forward_warmup::execution": {
+                    "num_iterations": 12,
+                    "total_ms": 5167.765378952026,
+                    "cpu_utilization": 23.3,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 24,
+                    "total_ms": 10363.693237304688,
+                    "cpu_utilization": 23.2,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 4668915712,
+                "cleanup::memory_cpu::pre": 52693569536,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 52693544960,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 52699279360,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 52693544960
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 52693544960,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 52693250048,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 52693250048,
+                "forward::memory_gpu::post": 4668915712,
+                "forward::memory_cpu::post": 52714364928,
+                "forward_warmup::execution": {
+                    "num_iterations": 8,
+                    "total_ms": 5085.519790649414,
+                    "cpu_utilization": 16.8,
+                    "gpu_utilization": 92
+                },
+                "forward::execution": {
+                    "num_iterations": 16,
+                    "total_ms": 10182.602167129517,
+                    "cpu_utilization": 16.9,
+                    "gpu_utilization": 99
+                },
+                "cleanup::memory_gpu::pre": 4668915712,
+                "cleanup::memory_cpu::pre": 52690391040,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 52690288640,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 52693544960,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 52690288640
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 52690288640,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 52794937344,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 52750213120,
+                "forward::memory_gpu::post": 5985927168,
+                "forward::memory_cpu::post": 52750286848,
+                "forward_warmup::execution": {
+                    "num_iterations": 7,
+                    "total_ms": 5825.886964797974,
+                    "cpu_utilization": 13.7,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 13,
+                    "total_ms": 10808.318376541138,
+                    "cpu_utilization": 13.6,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 5985927168,
+                "cleanup::memory_cpu::pre": 52749582336,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 52749582336,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 52690288640,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 52749582336
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 52749582336,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 52751368192,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 52773003264,
+                "forward::memory_gpu::post": 5985927168,
+                "forward::memory_cpu::post": 52772958208,
+                "forward_warmup::execution": {
+                    "num_iterations": 5,
+                    "total_ms": 6231.936693191528,
+                    "cpu_utilization": 10.2,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 9,
+                    "total_ms": 11217.170000076294,
+                    "cpu_utilization": 10.1,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 5985927168,
+                "cleanup::memory_cpu::pre": 52749463552,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 52749631488,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 52749582336,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 52749631488
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 52749631488,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 52748206080,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 52773371904,
+                "forward::memory_gpu::post": 8624144384,
+                "forward::memory_cpu::post": 52748791808,
+                "forward_warmup::execution": {
+                    "num_iterations": 4,
+                    "total_ms": 6581.643104553223,
+                    "cpu_utilization": 8.4,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 7,
+                    "total_ms": 11528.99432182312,
+                    "cpu_utilization": 8.5,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 8624144384,
+                "cleanup::memory_cpu::pre": 52747804672,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 52748546048,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 52749631488,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 52748546048
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 256,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 52748546048,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 52745646080,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 52749524992,
+                "forward::memory_gpu::post": 8624144384,
+                "forward::memory_cpu::post": 52746022912,
+                "forward_warmup::execution": {
+                    "num_iterations": 3,
+                    "total_ms": 7451.4265060424805,
+                    "cpu_utilization": 6.6,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 5,
+                    "total_ms": 12408.527135848999,
+                    "cpu_utilization": 6.5,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 8624144384,
+                "cleanup::memory_cpu::pre": 52742266880,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 52749443072,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 52748546048,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 52749443072
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 256,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 52749443072,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 52811214848,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 52809994240,
+                "forward::memory_gpu::post": 13898481664,
+                "forward::memory_cpu::post": 52785160192,
+                "forward_warmup::execution": {
+                    "num_iterations": 2,
+                    "total_ms": 6606.894969940186,
+                    "cpu_utilization": 5.7,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 4,
+                    "total_ms": 13234.848022460938,
+                    "cpu_utilization": 5.7,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 13898481664,
+                "cleanup::memory_cpu::pre": 52804608000,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 52804608000,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 52749443072,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 52804608000
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 512,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 52804608000,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 52781903872,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 52781723648,
+                "forward::memory_gpu::post": 13898481664,
+                "forward::memory_cpu::post": 52777435136,
+                "forward_warmup::execution": {
+                    "num_iterations": 2,
+                    "total_ms": 9963.032245635986,
+                    "cpu_utilization": 4.7,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 3,
+                    "total_ms": 14964.268445968628,
+                    "cpu_utilization": 4.9,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 13898481664,
+                "cleanup::memory_cpu::pre": 52802564096,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 52779323392,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 52804608000,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 52779323392
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 512,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 52780093440,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 52777562112,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 52778983424,
+                "forward::memory_gpu::post": 24461836288,
+                "forward::memory_cpu::post": 52781662208,
+                "forward_warmup::execution": {
+                    "num_iterations": 1,
+                    "total_ms": 6497.403860092163,
+                    "cpu_utilization": 4.7,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 2,
+                    "total_ms": 12956.841468811035,
+                    "cpu_utilization": 4.6,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 24461836288,
+                "cleanup::memory_cpu::pre": 52782579712,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 52790575104,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 52780093440,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 52790575104
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1024,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::openai/clip-vit-large-patch14",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 52792123392,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 53122752512,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 53100736512,
+                "forward::memory_gpu::post": 24461836288,
+                "forward::memory_cpu::post": 52780249088,
+                "forward_warmup::execution": {
+                    "num_iterations": 1,
+                    "total_ms": 10024.649620056152,
+                    "cpu_utilization": 3.8,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 1,
+                    "total_ms": 10021.014928817749,
+                    "cpu_utilization": 3.8,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 24461836288,
+                "cleanup::memory_cpu::pre": 52807262208,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 52807507968,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 52792123392,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 52807507968
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1024,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 52807507968,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 55614304256,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 55614304256,
+                "forward::memory_gpu::post": 5673451520,
+                "forward::memory_cpu::post": 55614304256,
+                "forward_warmup::execution": {
+                    "num_iterations": 296,
+                    "total_ms": 5003.907203674316,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 91
+                },
+                "forward::execution": {
+                    "num_iterations": 595,
+                    "total_ms": 10015.69128036499,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 91
+                },
+                "cleanup::memory_gpu::pre": 5673451520,
+                "cleanup::memory_cpu::pre": 55624593408,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 55623823360,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 52807507968,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 55623823360
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 55623458816,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 58952949760,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 58952949760,
+                "forward::memory_gpu::post": 5673451520,
+                "forward::memory_cpu::post": 58952949760,
+                "forward_warmup::execution": {
+                    "num_iterations": 246,
+                    "total_ms": 5006.2415599823,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 75
+                },
+                "forward::execution": {
+                    "num_iterations": 488,
+                    "total_ms": 10017.20666885376,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 76
+                },
+                "cleanup::memory_gpu::pre": 5673451520,
+                "cleanup::memory_cpu::pre": 58931216384,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 58931519488,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 55623458816,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 58931519488
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 58931003392,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 58991210496,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 58992758784,
+                "forward::memory_gpu::post": 5694423040,
+                "forward::memory_cpu::post": 58996154368,
+                "forward_warmup::execution": {
+                    "num_iterations": 171,
+                    "total_ms": 5010.443687438965,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 90
+                },
+                "forward::execution": {
+                    "num_iterations": 341,
+                    "total_ms": 10005.574703216553,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 91
+                },
+                "cleanup::memory_gpu::pre": 5694423040,
+                "cleanup::memory_cpu::pre": 59009839104,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 58986799104,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 58931003392,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 58986799104
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 58907316224,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 58909061120,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 58909061120,
+                "forward::memory_gpu::post": 5694423040,
+                "forward::memory_cpu::post": 58913058816,
+                "forward_warmup::execution": {
+                    "num_iterations": 137,
+                    "total_ms": 5018.725156784058,
+                    "cpu_utilization": 51.2,
+                    "gpu_utilization": 74
+                },
+                "forward::execution": {
+                    "num_iterations": 274,
+                    "total_ms": 10003.978252410889,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 72
+                },
+                "cleanup::memory_gpu::pre": 5694423040,
+                "cleanup::memory_cpu::pre": 58939367424,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 58916888576,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 58907316224,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 58916888576
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 58916380672,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 58913513472,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 58913513472,
+                "forward::memory_gpu::post": 5778309120,
+                "forward::memory_cpu::post": 58913513472,
+                "forward_warmup::execution": {
+                    "num_iterations": 102,
+                    "total_ms": 5019.248962402344,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 88
+                },
+                "forward::execution": {
+                    "num_iterations": 204,
+                    "total_ms": 10010.746955871582,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 87
+                },
+                "cleanup::memory_gpu::pre": 5778309120,
+                "cleanup::memory_cpu::pre": 58934808576,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 58913406976,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 58916380672,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 58913406976
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 58913406976,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 58910638080,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 58910638080,
+                "forward::memory_gpu::post": 5778309120,
+                "forward::memory_cpu::post": 58911408128,
+                "forward_warmup::execution": {
+                    "num_iterations": 80,
+                    "total_ms": 5061.9797706604,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 65
+                },
+                "forward::execution": {
+                    "num_iterations": 160,
+                    "total_ms": 10024.90234375,
+                    "cpu_utilization": 51.7,
+                    "gpu_utilization": 71
+                },
+                "cleanup::memory_gpu::pre": 5778309120,
+                "cleanup::memory_cpu::pre": 58931367936,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 58908135424,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 58913406976,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 58908135424
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 58908135424,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 58905006080,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 58905649152,
+                "forward::memory_gpu::post": 5897846784,
+                "forward::memory_cpu::post": 58905878528,
+                "forward_warmup::execution": {
+                    "num_iterations": 52,
+                    "total_ms": 5001.876354217529,
+                    "cpu_utilization": 52.3,
+                    "gpu_utilization": 88
+                },
+                "forward::execution": {
+                    "num_iterations": 104,
+                    "total_ms": 10027.12869644165,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 89
+                },
+                "cleanup::memory_gpu::pre": 5897846784,
+                "cleanup::memory_cpu::pre": 58931580928,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 58911408128,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 58908135424,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 58911408128
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 58908311552,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 58913234944,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 58913234944,
+                "forward::memory_gpu::post": 5897846784,
+                "forward::memory_cpu::post": 58918912000,
+                "forward_warmup::execution": {
+                    "num_iterations": 41,
+                    "total_ms": 5031.657695770264,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 63
+                },
+                "forward::execution": {
+                    "num_iterations": 82,
+                    "total_ms": 10075.893640518188,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 81
+                },
+                "cleanup::memory_gpu::pre": 5897846784,
+                "cleanup::memory_cpu::pre": 58932322304,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 58907754496,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 58908311552,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 58907754496
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 58907754496,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 58902114304,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 58902114304,
+                "forward::memory_gpu::post": 6143213568,
+                "forward::memory_cpu::post": 58922971136,
+                "forward_warmup::execution": {
+                    "num_iterations": 28,
+                    "total_ms": 5100.229024887085,
+                    "cpu_utilization": 50.3,
+                    "gpu_utilization": 80
+                },
+                "forward::execution": {
+                    "num_iterations": 55,
+                    "total_ms": 10028.419971466064,
+                    "cpu_utilization": 50.5,
+                    "gpu_utilization": 89
+                },
+                "cleanup::memory_gpu::pre": 6143213568,
+                "cleanup::memory_cpu::pre": 58899771392,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 58900000768,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 58907754496,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 58900000768
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 58900000768,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 58928320512,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 58927804416,
+                "forward::memory_gpu::post": 6143213568,
+                "forward::memory_cpu::post": 58905128960,
+                "forward_warmup::execution": {
+                    "num_iterations": 22,
+                    "total_ms": 5171.2706089019775,
+                    "cpu_utilization": 39.8,
+                    "gpu_utilization": 74
+                },
+                "forward::execution": {
+                    "num_iterations": 43,
+                    "total_ms": 10128.317832946777,
+                    "cpu_utilization": 39.7,
+                    "gpu_utilization": 63
+                },
+                "cleanup::memory_gpu::pre": 6143213568,
+                "cleanup::memory_cpu::pre": 58897199104,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 58897068032,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 58900000768,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 58897068032
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 58897068032,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 58897657856,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 58897657856,
+                "forward::memory_gpu::post": 6592004096,
+                "forward::memory_cpu::post": 58897653760,
+                "forward_warmup::execution": {
+                    "num_iterations": 15,
+                    "total_ms": 5210.050582885742,
+                    "cpu_utilization": 27.8,
+                    "gpu_utilization": 81
+                },
+                "forward::execution": {
+                    "num_iterations": 29,
+                    "total_ms": 10093.217372894287,
+                    "cpu_utilization": 27.9,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 6592004096,
+                "cleanup::memory_cpu::pre": 58931068928,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 58905190400,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 58897068032,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 58905190400
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 58905190400,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 58911539200,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 58916954112,
+                "forward::memory_gpu::post": 6592004096,
+                "forward::memory_cpu::post": 58906075136,
+                "forward_warmup::execution": {
+                    "num_iterations": 12,
+                    "total_ms": 5415.253162384033,
+                    "cpu_utilization": 22.4,
+                    "gpu_utilization": 76
+                },
+                "forward::execution": {
+                    "num_iterations": 23,
+                    "total_ms": 10412.26601600647,
+                    "cpu_utilization": 22.1,
+                    "gpu_utilization": 68
+                },
+                "cleanup::memory_gpu::pre": 6592004096,
+                "cleanup::memory_cpu::pre": 58910572544,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 58911211520,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 58905190400,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 58911211520
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 58911211520,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 58913710080,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 58913554432,
+                "forward::memory_gpu::post": 7512653824,
+                "forward::memory_cpu::post": 58911072256,
+                "forward_warmup::execution": {
+                    "num_iterations": 8,
+                    "total_ms": 5596.434831619263,
+                    "cpu_utilization": 15.4,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 15,
+                    "total_ms": 10491.011619567871,
+                    "cpu_utilization": 15.4,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 7512653824,
+                "cleanup::memory_cpu::pre": 58931245056,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 58908004352,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 58911211520,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 58908004352
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 58908004352,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 58916159488,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 58933370880,
+                "forward::memory_gpu::post": 7512653824,
+                "forward::memory_cpu::post": 58910154752,
+                "forward_warmup::execution": {
+                    "num_iterations": 6,
+                    "total_ms": 5441.685676574707,
+                    "cpu_utilization": 12.4,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 12,
+                    "total_ms": 10861.164569854736,
+                    "cpu_utilization": 12.9,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 7512653824,
+                "cleanup::memory_cpu::pre": 58932355072,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 58908086272,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 58908004352,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 58908086272
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 58908086272,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 58906509312,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 58919399424,
+                "forward::memory_gpu::post": 9353953280,
+                "forward::memory_cpu::post": 58907426816,
+                "forward_warmup::execution": {
+                    "num_iterations": 4,
+                    "total_ms": 5458.7578773498535,
+                    "cpu_utilization": 9.5,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 8,
+                    "total_ms": 10911.485195159912,
+                    "cpu_utilization": 9.4,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 9353953280,
+                "cleanup::memory_cpu::pre": 58899902464,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 58900647936,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 58908086272,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 58900647936
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 58900647936,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 59032141824,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 59032449024,
+                "forward::memory_gpu::post": 9353953280,
+                "forward::memory_cpu::post": 59035049984,
+                "forward_warmup::execution": {
+                    "num_iterations": 3,
+                    "total_ms": 5331.149339675903,
+                    "cpu_utilization": 8.0,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 6,
+                    "total_ms": 10669.147253036499,
+                    "cpu_utilization": 7.9,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 9353953280,
+                "cleanup::memory_cpu::pre": 59053203456,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59053305856,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 58900647936,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59053305856
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59053305856,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 59053920256,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 59076870144,
+                "forward::memory_gpu::post": 13034455040,
+                "forward::memory_cpu::post": 59053318144,
+                "forward_warmup::execution": {
+                    "num_iterations": 2,
+                    "total_ms": 5420.0780391693115,
+                    "cpu_utilization": 6.8,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 4,
+                    "total_ms": 10938.071012496948,
+                    "cpu_utilization": 6.2,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 13034455040,
+                "cleanup::memory_cpu::pre": 59058507776,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59077062656,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59053305856,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59077062656
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 256,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59077062656,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 59061723136,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 59084914688,
+                "forward::memory_gpu::post": 13034455040,
+                "forward::memory_cpu::post": 59061800960,
+                "forward_warmup::execution": {
+                    "num_iterations": 2,
+                    "total_ms": 7133.246898651123,
+                    "cpu_utilization": 5.6,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 3,
+                    "total_ms": 10702.292442321777,
+                    "cpu_utilization": 5.4,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 13034455040,
+                "cleanup::memory_cpu::pre": 59064864768,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59088011264,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59077062656,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59088011264
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 256,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59088011264,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 59145736192,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 59142709248,
+                "forward::memory_gpu::post": 20405944320,
+                "forward::memory_cpu::post": 59163947008,
+                "forward_warmup::execution": {
+                    "num_iterations": 1,
+                    "total_ms": 5335.9105587005615,
+                    "cpu_utilization": 4.5,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 2,
+                    "total_ms": 10696.427345275879,
+                    "cpu_utilization": 4.7,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 20405944320,
+                "cleanup::memory_cpu::pre": 59160236032,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59137466368,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59088011264,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59137466368
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 512,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59137466368,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 59142955008,
+                "forward::memory_gpu::pre": 5650382848,
+                "forward::memory_cpu::pre": 59143323648,
+                "forward::memory_gpu::post": 20405944320,
+                "forward::memory_cpu::post": 59165958144,
+                "forward_warmup::execution": {
+                    "num_iterations": 1,
+                    "total_ms": 7060.442209243774,
+                    "cpu_utilization": 4.2,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 2,
+                    "total_ms": 14108.510971069336,
+                    "cpu_utilization": 4.3,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 20405944320,
+                "cleanup::memory_cpu::pre": 59164762112,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59141492736,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59137466368,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59141492736
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 512,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59141492736,
+                "init::memory_gpu::post": 5650382848,
+                "init::memory_cpu::post": 59151675392,
+                "cleanup::memory_gpu::pre": 21091713024,
+                "cleanup::memory_cpu::pre": 59151962112,
+                "cleanup::memory_gpu::post": 21091713024,
+                "cleanup::memory_cpu::post": 59151962112
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1024,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 21091713024,
+                "init::memory_cpu::pre": 59151519744,
+                "init::memory_gpu::post": 21091713024,
+                "init::memory_cpu::post": 59149606912,
+                "forward::memory_gpu::pre": 21091713024,
+                "forward::memory_cpu::pre": 59149606912,
+                "forward::memory_gpu::post": 21091713024,
+                "forward::memory_cpu::post": 59149606912,
+                "forward_warmup::execution": {
+                    "num_iterations": 448,
+                    "total_ms": 5004.175662994385,
+                    "cpu_utilization": 51.2,
+                    "gpu_utilization": 78
+                },
+                "forward::execution": {
+                    "num_iterations": 879,
+                    "total_ms": 10009.373188018799,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 77
+                },
+                "cleanup::memory_gpu::pre": 21091713024,
+                "cleanup::memory_cpu::pre": 59151765504,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59142705152,
+                "wrap::memory_gpu::pre": 21091713024,
+                "wrap::memory_cpu::pre": 59151519744,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59142705152
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59142705152,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59142295552,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59142295552,
+                "forward::memory_gpu::post": 3351904256,
+                "forward::memory_cpu::post": 59142295552,
+                "forward_warmup::execution": {
+                    "num_iterations": 343,
+                    "total_ms": 5004.389047622681,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 59
+                },
+                "forward::execution": {
+                    "num_iterations": 693,
+                    "total_ms": 10001.527070999146,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 61
+                },
+                "cleanup::memory_gpu::pre": 3351904256,
+                "cleanup::memory_cpu::pre": 59144634368,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59144704000,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59142705152,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59144704000
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59144704000,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59143319552,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59143319552,
+                "forward::memory_gpu::post": 3372875776,
+                "forward::memory_cpu::post": 59143319552,
+                "forward_warmup::execution": {
+                    "num_iterations": 286,
+                    "total_ms": 5007.027387619019,
+                    "cpu_utilization": 51.2,
+                    "gpu_utilization": 83
+                },
+                "forward::execution": {
+                    "num_iterations": 572,
+                    "total_ms": 10001.83916091919,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 85
+                },
+                "cleanup::memory_gpu::pre": 3372875776,
+                "cleanup::memory_cpu::pre": 59139837952,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59139837952,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59144704000,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59139837952
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59139837952,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59142340608,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59142340608,
+                "forward::memory_gpu::post": 3372875776,
+                "forward::memory_cpu::post": 59142332416,
+                "forward_warmup::execution": {
+                    "num_iterations": 202,
+                    "total_ms": 5014.370918273926,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 61
+                },
+                "forward::execution": {
+                    "num_iterations": 406,
+                    "total_ms": 10004.70495223999,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 61
+                },
+                "cleanup::memory_gpu::pre": 3372875776,
+                "cleanup::memory_cpu::pre": 59145654272,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59145883648,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59139837952,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59145883648
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59145883648,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59142598656,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59142598656,
+                "forward::memory_gpu::post": 3410624512,
+                "forward::memory_cpu::post": 59142516736,
+                "forward_warmup::execution": {
+                    "num_iterations": 176,
+                    "total_ms": 5027.509689331055,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 80
+                },
+                "forward::execution": {
+                    "num_iterations": 351,
+                    "total_ms": 10015.371322631836,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 80
+                },
+                "cleanup::memory_gpu::pre": 3410624512,
+                "cleanup::memory_cpu::pre": 59141984256,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59141984256,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59145883648,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59141984256
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59141984256,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59145674752,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59143094272,
+                "forward::memory_gpu::post": 3410624512,
+                "forward::memory_cpu::post": 59143094272,
+                "forward_warmup::execution": {
+                    "num_iterations": 119,
+                    "total_ms": 5037.865400314331,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 55
+                },
+                "forward::execution": {
+                    "num_iterations": 237,
+                    "total_ms": 10041.791439056396,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 57
+                },
+                "cleanup::memory_gpu::pre": 3410624512,
+                "cleanup::memory_cpu::pre": 59136708608,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59136708608,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59141984256,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59136708608
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59136708608,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59138727936,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59138727936,
+                "forward::memory_gpu::post": 3500802048,
+                "forward::memory_cpu::post": 59138727936,
+                "forward_warmup::execution": {
+                    "num_iterations": 91,
+                    "total_ms": 5001.684665679932,
+                    "cpu_utilization": 51.2,
+                    "gpu_utilization": 76
+                },
+                "forward::execution": {
+                    "num_iterations": 182,
+                    "total_ms": 10003.483295440674,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 80
+                },
+                "cleanup::memory_gpu::pre": 3500802048,
+                "cleanup::memory_cpu::pre": 59146207232,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59146137600,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59136708608,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59146137600
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59146137600,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59145650176,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59145641984,
+                "forward::memory_gpu::post": 3500802048,
+                "forward::memory_cpu::post": 59146121216,
+                "forward_warmup::execution": {
+                    "num_iterations": 61,
+                    "total_ms": 5018.3305740356445,
+                    "cpu_utilization": 51.2,
+                    "gpu_utilization": 60
+                },
+                "forward::execution": {
+                    "num_iterations": 121,
+                    "total_ms": 10003.796100616455,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 61
+                },
+                "cleanup::memory_gpu::pre": 3500802048,
+                "cleanup::memory_cpu::pre": 59143712768,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59143712768,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59146137600,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59143712768
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59143712768,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59144458240,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59144458240,
+                "forward::memory_gpu::post": 3689545728,
+                "forward::memory_cpu::post": 59143942144,
+                "forward_warmup::execution": {
+                    "num_iterations": 47,
+                    "total_ms": 5108.184814453125,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 78
+                },
+                "forward::execution": {
+                    "num_iterations": 92,
+                    "total_ms": 10013.915538787842,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 77
+                },
+                "cleanup::memory_gpu::pre": 3689545728,
+                "cleanup::memory_cpu::pre": 59143655424,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59147005952,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59143712768,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59147005952
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59148038144,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59146985472,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59146985472,
+                "forward::memory_gpu::post": 3689545728,
+                "forward::memory_cpu::post": 59147214848,
+                "forward_warmup::execution": {
+                    "num_iterations": 32,
+                    "total_ms": 5142.709016799927,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 62
+                },
+                "forward::execution": {
+                    "num_iterations": 63,
+                    "total_ms": 10073.932409286499,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 64
+                },
+                "cleanup::memory_gpu::pre": 3689545728,
+                "cleanup::memory_cpu::pre": 59171098624,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59171844096,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59148038144,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59171844096
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59171844096,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59145584640,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59145584640,
+                "forward::memory_gpu::post": 4008312832,
+                "forward::memory_cpu::post": 59152031744,
+                "forward_warmup::execution": {
+                    "num_iterations": 25,
+                    "total_ms": 5002.997398376465,
+                    "cpu_utilization": 46.3,
+                    "gpu_utilization": 78
+                },
+                "forward::execution": {
+                    "num_iterations": 50,
+                    "total_ms": 10074.23186302185,
+                    "cpu_utilization": 46.0,
+                    "gpu_utilization": 79
+                },
+                "cleanup::memory_gpu::pre": 4008312832,
+                "cleanup::memory_cpu::pre": 59167842304,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59143794688,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59171844096,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59143794688
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59143794688,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59170340864,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59170340864,
+                "forward::memory_gpu::post": 4008312832,
+                "forward::memory_cpu::post": 59147091968,
+                "forward_warmup::execution": {
+                    "num_iterations": 17,
+                    "total_ms": 5151.00884437561,
+                    "cpu_utilization": 31.4,
+                    "gpu_utilization": 63
+                },
+                "forward::execution": {
+                    "num_iterations": 33,
+                    "total_ms": 10019.29783821106,
+                    "cpu_utilization": 31.5,
+                    "gpu_utilization": 51
+                },
+                "cleanup::memory_gpu::pre": 4008312832,
+                "cleanup::memory_cpu::pre": 59146502144,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59146502144,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59143794688,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59146502144
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59146502144,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59146375168,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59146055680,
+                "forward::memory_gpu::post": 4671012864,
+                "forward::memory_cpu::post": 59168215040,
+                "forward_warmup::execution": {
+                    "num_iterations": 13,
+                    "total_ms": 5059.758186340332,
+                    "cpu_utilization": 25.5,
+                    "gpu_utilization": 84
+                },
+                "forward::execution": {
+                    "num_iterations": 26,
+                    "total_ms": 10109.525442123413,
+                    "cpu_utilization": 25.8,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 4671012864,
+                "cleanup::memory_cpu::pre": 59146436608,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59146665984,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59146502144,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59146665984
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59146665984,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59168440320,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59145236480,
+                "forward::memory_gpu::post": 4671012864,
+                "forward::memory_cpu::post": 59145158656,
+                "forward_warmup::execution": {
+                    "num_iterations": 9,
+                    "total_ms": 5492.1910762786865,
+                    "cpu_utilization": 17.3,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 17,
+                    "total_ms": 10358.859062194824,
+                    "cpu_utilization": 17.3,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 4671012864,
+                "cleanup::memory_cpu::pre": 59147489280,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59169423360,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59146665984,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59169423360
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59169423360,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59150807040,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59152723968,
+                "forward::memory_gpu::post": 5990121472,
+                "forward::memory_cpu::post": 59150802944,
+                "forward_warmup::execution": {
+                    "num_iterations": 7,
+                    "total_ms": 5394.023895263672,
+                    "cpu_utilization": 14.4,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 13,
+                    "total_ms": 10050.098657608032,
+                    "cpu_utilization": 14.5,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 5990121472,
+                "cleanup::memory_cpu::pre": 59175526400,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59152285696,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59169423360,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59152285696
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59152285696,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59156967424,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59177508864,
+                "forward::memory_gpu::post": 5990121472,
+                "forward::memory_cpu::post": 59178516480,
+                "forward_warmup::execution": {
+                    "num_iterations": 5,
+                    "total_ms": 5928.748369216919,
+                    "cpu_utilization": 10.4,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 9,
+                    "total_ms": 10657.3166847229,
+                    "cpu_utilization": 10.4,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 5990121472,
+                "cleanup::memory_cpu::pre": 59149520896,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59168579584,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59152285696,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59169611776
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59172708352,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59150106624,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59173859328,
+                "forward::memory_gpu::post": 8630435840,
+                "forward::memory_cpu::post": 59152343040,
+                "forward_warmup::execution": {
+                    "num_iterations": 4,
+                    "total_ms": 6112.439393997192,
+                    "cpu_utilization": 9.0,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 7,
+                    "total_ms": 10732.749223709106,
+                    "cpu_utilization": 8.8,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 8630435840,
+                "cleanup::memory_cpu::pre": 59177332736,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59153330176,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59172708352,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59153330176
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 256,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59153330176,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59173281792,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59150241792,
+                "forward::memory_gpu::post": 8630435840,
+                "forward::memory_cpu::post": 59148828672,
+                "forward_warmup::execution": {
+                    "num_iterations": 3,
+                    "total_ms": 7113.27862739563,
+                    "cpu_utilization": 6.7,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 5,
+                    "total_ms": 11860.47911643982,
+                    "cpu_utilization": 6.8,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 8630435840,
+                "cleanup::memory_cpu::pre": 59172769792,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59149533184,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59153330176,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59149533184
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 256,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59149533184,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59168722944,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59166523392,
+                "forward::memory_gpu::post": 13908967424,
+                "forward::memory_cpu::post": 59146985472,
+                "forward_warmup::execution": {
+                    "num_iterations": 2,
+                    "total_ms": 6106.618165969849,
+                    "cpu_utilization": 6.1,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 4,
+                    "total_ms": 12223.78134727478,
+                    "cpu_utilization": 6.0,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 13908967424,
+                "cleanup::memory_cpu::pre": 59153342464,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59153321984,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59149533184,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59153321984
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 512,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59153321984,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59152224256,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59150917632,
+                "forward::memory_gpu::post": 13908967424,
+                "forward::memory_cpu::post": 59161124864,
+                "forward_warmup::execution": {
+                    "num_iterations": 2,
+                    "total_ms": 9498.842000961304,
+                    "cpu_utilization": 4.9,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 3,
+                    "total_ms": 14217.618703842163,
+                    "cpu_utilization": 4.8,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 13908967424,
+                "cleanup::memory_cpu::pre": 59162828800,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59173044224,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59153321984,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59173560320
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 512,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59185430528,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59152867328,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59159949312,
+                "forward::memory_gpu::post": 24480710656,
+                "forward::memory_cpu::post": 59163820032,
+                "forward_warmup::execution": {
+                    "num_iterations": 1,
+                    "total_ms": 5934.8156452178955,
+                    "cpu_utilization": 4.5,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 2,
+                    "total_ms": 11879.544019699097,
+                    "cpu_utilization": 5.3,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 24480710656,
+                "cleanup::memory_cpu::pre": 59176964096,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59153969152,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59185430528,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59153969152
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1024,
+            "shape": [
+                224,
+                224
+            ]
+        },
+        {
+            "namespace": "nos::laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59153969152,
+                "init::memory_gpu::post": 3328835584,
+                "init::memory_cpu::post": 59177594880,
+                "forward::memory_gpu::pre": 3328835584,
+                "forward::memory_cpu::pre": 59163033600,
+                "forward::memory_gpu::post": 24480710656,
+                "forward::memory_cpu::post": 59183243264,
+                "forward_warmup::execution": {
+                    "num_iterations": 1,
+                    "total_ms": 9319.140434265137,
+                    "cpu_utilization": 5.4,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 2,
+                    "total_ms": 18669.757843017578,
+                    "cpu_utilization": 4.9,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 24480710656,
+                "cleanup::memory_cpu::pre": 59272138752,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59286327296,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59153969152,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59286327296
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1024,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59286327296,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59263074304,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59263074304,
+                "forward::memory_gpu::post": 1856634880,
+                "forward::memory_cpu::post": 59263074304,
+                "forward_warmup::execution": {
+                    "num_iterations": 383,
+                    "total_ms": 5004.1632652282715,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 21
+                },
+                "forward::execution": {
+                    "num_iterations": 758,
+                    "total_ms": 10013.597249984741,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 21
+                },
+                "cleanup::memory_gpu::pre": 1856634880,
+                "cleanup::memory_cpu::pre": 59262824448,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59262824448,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59286327296,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59262824448
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59262824448,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59285999616,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59285999616,
+                "forward::memory_gpu::post": 1869217792,
+                "forward::memory_cpu::post": 59285999616,
+                "forward_warmup::execution": {
+                    "num_iterations": 320,
+                    "total_ms": 5011.746168136597,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 21
+                },
+                "forward::execution": {
+                    "num_iterations": 646,
+                    "total_ms": 10015.671730041504,
+                    "cpu_utilization": 51.7,
+                    "gpu_utilization": 21
+                },
+                "cleanup::memory_gpu::pre": 1869217792,
+                "cleanup::memory_cpu::pre": 59265134592,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59262402560,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59262824448,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59262402560
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59262402560,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59262402560,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59262402560,
+                "forward::memory_gpu::post": 1915355136,
+                "forward::memory_cpu::post": 59262402560,
+                "forward_warmup::execution": {
+                    "num_iterations": 272,
+                    "total_ms": 5002.256631851196,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 22
+                },
+                "forward::execution": {
+                    "num_iterations": 542,
+                    "total_ms": 10008.088827133179,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 22
+                },
+                "cleanup::memory_gpu::pre": 1915355136,
+                "cleanup::memory_cpu::pre": 59269218304,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59269218304,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59262402560,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59269218304
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59269218304,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59292172288,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59292172288,
+                "forward::memory_gpu::post": 1894383616,
+                "forward::memory_cpu::post": 59292172288,
+                "forward_warmup::execution": {
+                    "num_iterations": 314,
+                    "total_ms": 5016.434192657471,
+                    "cpu_utilization": 52.2,
+                    "gpu_utilization": 22
+                },
+                "forward::execution": {
+                    "num_iterations": 638,
+                    "total_ms": 10006.447076797485,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 23
+                },
+                "cleanup::memory_gpu::pre": 1894383616,
+                "cleanup::memory_cpu::pre": 59253313536,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59253182464,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59269218304,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59253182464
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59253182464,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59253182464,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59253182464,
+                "forward::memory_gpu::post": 1921646592,
+                "forward::memory_cpu::post": 59253121024,
+                "forward_warmup::execution": {
+                    "num_iterations": 240,
+                    "total_ms": 5002.298593521118,
+                    "cpu_utilization": 51.7,
+                    "gpu_utilization": 22
+                },
+                "forward::execution": {
+                    "num_iterations": 473,
+                    "total_ms": 10008.280992507935,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 21
+                },
+                "cleanup::memory_gpu::pre": 1921646592,
+                "cleanup::memory_cpu::pre": 59150036992,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59168329728,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59253182464,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59168329728
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59168329728,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59168329728,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59168329728,
+                "forward::memory_gpu::post": 1969881088,
+                "forward::memory_cpu::post": 59134750720,
+                "forward_warmup::execution": {
+                    "num_iterations": 174,
+                    "total_ms": 5025.866746902466,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 21
+                },
+                "forward::execution": {
+                    "num_iterations": 347,
+                    "total_ms": 10029.564380645752,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 21
+                },
+                "cleanup::memory_gpu::pre": 1969881088,
+                "cleanup::memory_cpu::pre": 59083112448,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59083354112,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59168329728,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59083354112
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59083354112,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59083612160,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59083612160,
+                "forward::memory_gpu::post": 1992949760,
+                "forward::memory_cpu::post": 59083612160,
+                "forward_warmup::execution": {
+                    "num_iterations": 236,
+                    "total_ms": 5009.329557418823,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 25
+                },
+                "forward::execution": {
+                    "num_iterations": 471,
+                    "total_ms": 10019.088506698608,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 26
+                },
+                "cleanup::memory_gpu::pre": 1992949760,
+                "cleanup::memory_cpu::pre": 59084939264,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59097284608,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59083354112,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59097800704
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59099348992,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59103993856,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59103993856,
+                "forward::memory_gpu::post": 2049572864,
+                "forward::memory_cpu::post": 59103993856,
+                "forward_warmup::execution": {
+                    "num_iterations": 171,
+                    "total_ms": 5007.193803787231,
+                    "cpu_utilization": 52.2,
+                    "gpu_utilization": 25
+                },
+                "forward::execution": {
+                    "num_iterations": 345,
+                    "total_ms": 10013.473510742188,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 25
+                },
+                "cleanup::memory_gpu::pre": 2049572864,
+                "cleanup::memory_cpu::pre": 59088691200,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59088691200,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59099348992,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59088691200
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59088691200,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59088654336,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59090202624,
+                "forward::memory_gpu::post": 2131361792,
+                "forward::memory_cpu::post": 59097427968,
+                "forward_warmup::execution": {
+                    "num_iterations": 102,
+                    "total_ms": 5015.147924423218,
+                    "cpu_utilization": 52.2,
+                    "gpu_utilization": 21
+                },
+                "forward::execution": {
+                    "num_iterations": 206,
+                    "total_ms": 10035.241842269897,
+                    "cpu_utilization": 52.2,
+                    "gpu_utilization": 21
+                },
+                "cleanup::memory_gpu::pre": 2131361792,
+                "cleanup::memory_cpu::pre": 59096883200,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59112366080,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59088691200,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59112366080
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59112366080,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59112624128,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59112624128,
+                "forward::memory_gpu::post": 2160721920,
+                "forward::memory_cpu::post": 59089612800,
+                "forward_warmup::execution": {
+                    "num_iterations": 159,
+                    "total_ms": 5032.262802124023,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 27
+                },
+                "forward::execution": {
+                    "num_iterations": 315,
+                    "total_ms": 10011.151552200317,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 27
+                },
+                "cleanup::memory_gpu::pre": 2160721920,
+                "cleanup::memory_cpu::pre": 59088007168,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59088494592,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59112366080,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59088494592
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59088494592,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59088494592,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59088494592,
+                "forward::memory_gpu::post": 2267676672,
+                "forward::memory_cpu::post": 59090042880,
+                "forward_warmup::execution": {
+                    "num_iterations": 97,
+                    "total_ms": 5024.095773696899,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 25
+                },
+                "forward::execution": {
+                    "num_iterations": 193,
+                    "total_ms": 10032.71198272705,
+                    "cpu_utilization": 52.3,
+                    "gpu_utilization": 23
+                },
+                "cleanup::memory_gpu::pre": 2267676672,
+                "cleanup::memory_cpu::pre": 59096064000,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59109507072,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59088494592,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59109507072
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59109507072,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59086266368,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59086450688,
+                "forward::memory_gpu::post": 2410283008,
+                "forward::memory_cpu::post": 59077668864,
+                "forward_warmup::execution": {
+                    "num_iterations": 60,
+                    "total_ms": 5078.831434249878,
+                    "cpu_utilization": 52.7,
+                    "gpu_utilization": 25
+                },
+                "forward::execution": {
+                    "num_iterations": 119,
+                    "total_ms": 10050.996541976929,
+                    "cpu_utilization": 52.5,
+                    "gpu_utilization": 21
+                },
+                "cleanup::memory_gpu::pre": 2410283008,
+                "cleanup::memory_cpu::pre": 59090104320,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59090235392,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59109507072,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59090235392
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59090235392,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59099348992,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59112767488,
+                "forward::memory_gpu::post": 2433351680,
+                "forward::memory_cpu::post": 59112767488,
+                "forward_warmup::execution": {
+                    "num_iterations": 99,
+                    "total_ms": 5049.835920333862,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 31
+                },
+                "forward::execution": {
+                    "num_iterations": 197,
+                    "total_ms": 10019.774913787842,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 31
+                },
+                "cleanup::memory_gpu::pre": 2433351680,
+                "cleanup::memory_cpu::pre": 59088261120,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59088261120,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59090235392,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59088261120
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59088261120,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59095474176,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59086168064,
+                "forward::memory_gpu::post": 2638872576,
+                "forward::memory_cpu::post": 59087171584,
+                "forward_warmup::execution": {
+                    "num_iterations": 56,
+                    "total_ms": 5013.494253158569,
+                    "cpu_utilization": 52.4,
+                    "gpu_utilization": 24
+                },
+                "forward::execution": {
+                    "num_iterations": 113,
+                    "total_ms": 10076.308727264404,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 25
+                },
+                "cleanup::memory_gpu::pre": 2638872576,
+                "cleanup::memory_cpu::pre": 59079966720,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59080138752,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59088261120,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59080138752
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59080138752,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59103629312,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59080609792,
+                "forward::memory_gpu::post": 2955542528,
+                "forward::memory_cpu::post": 59080040448,
+                "forward_warmup::execution": {
+                    "num_iterations": 34,
+                    "total_ms": 5027.608871459961,
+                    "cpu_utilization": 52.6,
+                    "gpu_utilization": 19
+                },
+                "forward::execution": {
+                    "num_iterations": 68,
+                    "total_ms": 10104.276657104492,
+                    "cpu_utilization": 53.0,
+                    "gpu_utilization": 29
+                },
+                "cleanup::memory_gpu::pre": 2955542528,
+                "cleanup::memory_cpu::pre": 59104239616,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59081854976,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59080138752,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59081854976
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59082371072,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59081449472,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59097264128,
+                "forward::memory_gpu::post": 3158966272,
+                "forward::memory_cpu::post": 59098980352,
+                "forward_warmup::execution": {
+                    "num_iterations": 51,
+                    "total_ms": 5043.039798736572,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 35
+                },
+                "forward::execution": {
+                    "num_iterations": 102,
+                    "total_ms": 10020.785808563232,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 33
+                },
+                "cleanup::memory_gpu::pre": 3158966272,
+                "cleanup::memory_cpu::pre": 59078455296,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59079442432,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59082371072,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59079442432
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59079442432,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59079737344,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59079512064,
+                "forward::memory_gpu::post": 3536453632,
+                "forward::memory_cpu::post": 59079512064,
+                "forward_warmup::execution": {
+                    "num_iterations": 30,
+                    "total_ms": 5113.000392913818,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 33
+                },
+                "forward::execution": {
+                    "num_iterations": 59,
+                    "total_ms": 10085.420370101929,
+                    "cpu_utilization": 52.5,
+                    "gpu_utilization": 24
+                },
+                "cleanup::memory_gpu::pre": 3536453632,
+                "cleanup::memory_cpu::pre": 59085606912,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59108769792,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59079442432,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59108769792
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59108769792,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59109515264,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59086704640,
+                "forward::memory_gpu::post": 4161404928,
+                "forward::memory_cpu::post": 59086704640,
+                "forward_warmup::execution": {
+                    "num_iterations": 18,
+                    "total_ms": 5191.220045089722,
+                    "cpu_utilization": 52.6,
+                    "gpu_utilization": 19
+                },
+                "forward::execution": {
+                    "num_iterations": 35,
+                    "total_ms": 10147.383689880371,
+                    "cpu_utilization": 52.4,
+                    "gpu_utilization": 31
+                },
+                "cleanup::memory_gpu::pre": 4161404928,
+                "cleanup::memory_cpu::pre": 59083194368,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59083472896,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59108769792,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59083472896
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59083472896,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59083300864,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59083300864,
+                "forward::memory_gpu::post": 4633264128,
+                "forward::memory_cpu::post": 59083300864,
+                "forward_warmup::execution": {
+                    "num_iterations": 26,
+                    "total_ms": 5052.480220794678,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 36
+                },
+                "forward::execution": {
+                    "num_iterations": 52,
+                    "total_ms": 10104.575157165527,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 34
+                },
+                "cleanup::memory_gpu::pre": 4633264128,
+                "cleanup::memory_cpu::pre": 59105992704,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59105988608,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59083472896,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59105988608
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59105988608,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59082530816,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59079704576,
+                "forward::memory_gpu::post": 5352587264,
+                "forward::memory_cpu::post": 59079704576,
+                "forward_warmup::execution": {
+                    "num_iterations": 15,
+                    "total_ms": 5185.792922973633,
+                    "cpu_utilization": 46.0,
+                    "gpu_utilization": 37
+                },
+                "forward::execution": {
+                    "num_iterations": 29,
+                    "total_ms": 10053.521871566772,
+                    "cpu_utilization": 46.2,
+                    "gpu_utilization": 20
+                },
+                "cleanup::memory_gpu::pre": 5352587264,
+                "cleanup::memory_cpu::pre": 59080863744,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59080384512,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59105988608,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59080384512
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59080384512,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59099414528,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59077914624,
+                "forward::memory_gpu::post": 6583615488,
+                "forward::memory_cpu::post": 59100704768,
+                "forward_warmup::execution": {
+                    "num_iterations": 9,
+                    "total_ms": 5092.850208282471,
+                    "cpu_utilization": 40.8,
+                    "gpu_utilization": 46
+                },
+                "forward::execution": {
+                    "num_iterations": 18,
+                    "total_ms": 10202.81457901001,
+                    "cpu_utilization": 40.9,
+                    "gpu_utilization": 48
+                },
+                "cleanup::memory_gpu::pre": 6583615488,
+                "cleanup::memory_cpu::pre": 59105357824,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59082260480,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59080384512,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59082260480
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59082080256,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59082481664,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59083476992,
+                "forward::memory_gpu::post": 7581859840,
+                "forward::memory_cpu::post": 59084038144,
+                "forward_warmup::execution": {
+                    "num_iterations": 13,
+                    "total_ms": 5005.056858062744,
+                    "cpu_utilization": 33.3,
+                    "gpu_utilization": 48
+                },
+                "forward::execution": {
+                    "num_iterations": 26,
+                    "total_ms": 10049.79157447815,
+                    "cpu_utilization": 33.1,
+                    "gpu_utilization": 24
+                },
+                "cleanup::memory_gpu::pre": 7581859840,
+                "cleanup::memory_cpu::pre": 59111337984,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59111051264,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59082080256,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59111051264
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59111051264,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59087425536,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59110858752,
+                "forward::memory_gpu::post": 9022603264,
+                "forward::memory_cpu::post": 59087020032,
+                "forward_warmup::execution": {
+                    "num_iterations": 8,
+                    "total_ms": 5422.2612380981445,
+                    "cpu_utilization": 34.0,
+                    "gpu_utilization": 53
+                },
+                "forward::execution": {
+                    "num_iterations": 15,
+                    "total_ms": 10186.380624771118,
+                    "cpu_utilization": 33.0,
+                    "gpu_utilization": 52
+                },
+                "cleanup::memory_gpu::pre": 9022603264,
+                "cleanup::memory_cpu::pre": 59112505344,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59112763392,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59111051264,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59112763392
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59112763392,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59089473536,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59090571264,
+                "forward::memory_gpu::post": 11415453696,
+                "forward::memory_cpu::post": 59080548352,
+                "forward_warmup::execution": {
+                    "num_iterations": 4,
+                    "total_ms": 5594.81143951416,
+                    "cpu_utilization": 29.3,
+                    "gpu_utilization": 43
+                },
+                "forward::execution": {
+                    "num_iterations": 8,
+                    "total_ms": 11258.748531341553,
+                    "cpu_utilization": 29.2,
+                    "gpu_utilization": 30
+                },
+                "cleanup::memory_gpu::pre": 11415453696,
+                "cleanup::memory_cpu::pre": 59076399104,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59099541504,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59112763392,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59099119616
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59099119616,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59099947008,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59075522560,
+                "forward::memory_gpu::post": 13506314240,
+                "forward::memory_cpu::post": 59099656192,
+                "forward_warmup::execution": {
+                    "num_iterations": 7,
+                    "total_ms": 5400.1195430755615,
+                    "cpu_utilization": 22.1,
+                    "gpu_utilization": 33
+                },
+                "forward::execution": {
+                    "num_iterations": 13,
+                    "total_ms": 10076.313257217407,
+                    "cpu_utilization": 21.9,
+                    "gpu_utilization": 34
+                },
+                "cleanup::memory_gpu::pre": 13506314240,
+                "cleanup::memory_cpu::pre": 59081486336,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59105153024,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59099119616,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59105153024
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 256,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59105153024,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59105153024,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59107508224,
+                "forward::memory_gpu::post": 16350052352,
+                "forward::memory_cpu::post": 59085373440,
+                "forward_warmup::execution": {
+                    "num_iterations": 4,
+                    "total_ms": 6096.827507019043,
+                    "cpu_utilization": 23.6,
+                    "gpu_utilization": 19
+                },
+                "forward::execution": {
+                    "num_iterations": 7,
+                    "total_ms": 10697.84951210022,
+                    "cpu_utilization": 23.5,
+                    "gpu_utilization": 34
+                },
+                "cleanup::memory_gpu::pre": 16350052352,
+                "cleanup::memory_cpu::pre": 59096297472,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59072548864,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59105153024,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59072548864
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 256,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59072548864,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59073777664,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59082690560,
+                "forward::memory_gpu::post": 21118976000,
+                "forward::memory_cpu::post": 59063967744,
+                "forward_warmup::execution": {
+                    "num_iterations": 2,
+                    "total_ms": 5719.8779582977295,
+                    "cpu_utilization": 24.3,
+                    "gpu_utilization": 33
+                },
+                "forward::execution": {
+                    "num_iterations": 4,
+                    "total_ms": 11454.976558685303,
+                    "cpu_utilization": 23.9,
+                    "gpu_utilization": 34
+                },
+                "cleanup::memory_gpu::pre": 21118976000,
+                "cleanup::memory_cpu::pre": 59071488000,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59071033344,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59072548864,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59071033344
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 256,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59071033344,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59071291392,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59097305088,
+                "forward::memory_gpu::post": 25334251520,
+                "forward::memory_cpu::post": 59077263360,
+                "forward_warmup::execution": {
+                    "num_iterations": 4,
+                    "total_ms": 6173.961639404297,
+                    "cpu_utilization": 16.1,
+                    "gpu_utilization": 16
+                },
+                "forward::execution": {
+                    "num_iterations": 7,
+                    "total_ms": 10784.391164779663,
+                    "cpu_utilization": 16.4,
+                    "gpu_utilization": 16
+                },
+                "cleanup::memory_gpu::pre": 25334251520,
+                "cleanup::memory_cpu::pre": 59102494720,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59102715904,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59071033344,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59102715904
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 512,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::torchvision/fasterrcnn_mobilenet_v3_large_320_fpn",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59102715904,
+                "init::memory_gpu::post": 1676279808,
+                "init::memory_cpu::post": 59079966720,
+                "forward::memory_gpu::pre": 1676279808,
+                "forward::memory_cpu::pre": 59104927744,
+                "forward::memory_gpu::post": 19034406912,
+                "forward::memory_cpu::post": 59088105472,
+                "cleanup::memory_gpu::pre": 23650238464,
+                "cleanup::memory_cpu::pre": 59153776640,
+                "cleanup::memory_gpu::post": 18952617984,
+                "cleanup::memory_cpu::post": 59146846208
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 512,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 18952617984,
+                "init::memory_cpu::pre": 59146846208,
+                "init::memory_gpu::post": 18961006592,
+                "init::memory_cpu::post": 59171422208,
+                "forward::memory_gpu::pre": 18961006592,
+                "forward::memory_cpu::pre": 59171422208,
+                "forward::memory_gpu::post": 18967298048,
+                "forward::memory_cpu::post": 59171422208,
+                "forward_warmup::execution": {
+                    "num_iterations": 589,
+                    "total_ms": 5005.816459655762,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 36
+                },
+                "forward::execution": {
+                    "num_iterations": 1176,
+                    "total_ms": 10005.777835845947,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 36
+                },
+                "cleanup::memory_gpu::pre": 18967298048,
+                "cleanup::memory_cpu::pre": 59156967424,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59158028288,
+                "wrap::memory_gpu::pre": 18952617984,
+                "wrap::memory_cpu::pre": 59146846208,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59158028288
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59158286336,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59171237888,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59171237888,
+                "forward::memory_gpu::post": 1930035200,
+                "forward::memory_cpu::post": 59171237888,
+                "forward_warmup::execution": {
+                    "num_iterations": 417,
+                    "total_ms": 5008.971452713013,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 50
+                },
+                "forward::execution": {
+                    "num_iterations": 837,
+                    "total_ms": 10011.013746261597,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 51
+                },
+                "cleanup::memory_gpu::pre": 1930035200,
+                "cleanup::memory_cpu::pre": 59149500416,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59150241792,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59158286336,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59150241792
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59150499840,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59150868480,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59150868480,
+                "forward::memory_gpu::post": 2202664960,
+                "forward::memory_cpu::post": 59150868480,
+                "forward_warmup::execution": {
+                    "num_iterations": 284,
+                    "total_ms": 5016.219139099121,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 66
+                },
+                "forward::execution": {
+                    "num_iterations": 566,
+                    "total_ms": 10013.25535774231,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 66
+                },
+                "cleanup::memory_gpu::pre": 2202664960,
+                "cleanup::memory_cpu::pre": 59175526400,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59176259584,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59150499840,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59176259584
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59176259584,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59175538688,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59175538688,
+                "forward::memory_gpu::post": 1946812416,
+                "forward::memory_cpu::post": 59175505920,
+                "forward_warmup::execution": {
+                    "num_iterations": 446,
+                    "total_ms": 5009.642124176025,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 38
+                },
+                "forward::execution": {
+                    "num_iterations": 898,
+                    "total_ms": 10012.718915939331,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 38
+                },
+                "cleanup::memory_gpu::pre": 1946812416,
+                "cleanup::memory_cpu::pre": 59150561280,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59150602240,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59176259584,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59150602240
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59150602240,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59150315520,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59150315520,
+                "forward::memory_gpu::post": 2152333312,
+                "forward::memory_cpu::post": 59150315520,
+                "forward_warmup::execution": {
+                    "num_iterations": 281,
+                    "total_ms": 5010.624408721924,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 55
+                },
+                "forward::execution": {
+                    "num_iterations": 564,
+                    "total_ms": 10016.712427139282,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 56
+                },
+                "cleanup::memory_gpu::pre": 2152333312,
+                "cleanup::memory_cpu::pre": 59161104384,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59160174592,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59150602240,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59160174592
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59160174592,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59160731648,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59160731648,
+                "forward::memory_gpu::post": 2489974784,
+                "forward::memory_cpu::post": 59160731648,
+                "forward_warmup::execution": {
+                    "num_iterations": 122,
+                    "total_ms": 5007.591009140015,
+                    "cpu_utilization": 52.4,
+                    "gpu_utilization": 57
+                },
+                "forward::execution": {
+                    "num_iterations": 244,
+                    "total_ms": 10006.678104400635,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 58
+                },
+                "cleanup::memory_gpu::pre": 2624192512,
+                "cleanup::memory_cpu::pre": 59164770304,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59184115712,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59160174592,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59184631808
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59186696192,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59167358976,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59169931264,
+                "forward::memory_gpu::post": 1930035200,
+                "forward::memory_cpu::post": 59174301696,
+                "forward_warmup::execution": {
+                    "num_iterations": 350,
+                    "total_ms": 5015.864849090576,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 44
+                },
+                "forward::execution": {
+                    "num_iterations": 703,
+                    "total_ms": 10017.984867095947,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 44
+                },
+                "cleanup::memory_gpu::pre": 1930035200,
+                "cleanup::memory_cpu::pre": 59183181824,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59159212032,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59186180096,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59159212032
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59159212032,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59159556096,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59159556096,
+                "forward::memory_gpu::post": 2389311488,
+                "forward::memory_cpu::post": 59159556096,
+                "forward_warmup::execution": {
+                    "num_iterations": 143,
+                    "total_ms": 5014.878273010254,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 54
+                },
+                "forward::execution": {
+                    "num_iterations": 286,
+                    "total_ms": 10022.343635559082,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 56
+                },
+                "cleanup::memory_gpu::pre": 2523529216,
+                "cleanup::memory_cpu::pre": 59158536192,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59158839296,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59159212032,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59158839296
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59158839296,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59158839296,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59166580736,
+                "forward::memory_gpu::post": 3737780224,
+                "forward::memory_cpu::post": 59181289472,
+                "forward_warmup::execution": {
+                    "num_iterations": 61,
+                    "total_ms": 5064.186811447144,
+                    "cpu_utilization": 52.6,
+                    "gpu_utilization": 61
+                },
+                "forward::execution": {
+                    "num_iterations": 121,
+                    "total_ms": 10045.874834060669,
+                    "cpu_utilization": 52.3,
+                    "gpu_utilization": 66
+                },
+                "cleanup::memory_gpu::pre": 3737780224,
+                "cleanup::memory_cpu::pre": 59179261952,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59179802624,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59158839296,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59179802624
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59179802624,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59156938752,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59156938752,
+                "forward::memory_gpu::post": 2332688384,
+                "forward::memory_cpu::post": 59156938752,
+                "forward_warmup::execution": {
+                    "num_iterations": 247,
+                    "total_ms": 5010.6353759765625,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 45
+                },
+                "forward::execution": {
+                    "num_iterations": 494,
+                    "total_ms": 10015.272378921509,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 47
+                },
+                "cleanup::memory_gpu::pre": 2332688384,
+                "cleanup::memory_cpu::pre": 59164807168,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59182542848,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59179802624,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59182542848
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59182542848,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59182538752,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59159302144,
+                "forward::memory_gpu::post": 3133800448,
+                "forward::memory_cpu::post": 59159302144,
+                "forward_warmup::execution": {
+                    "num_iterations": 71,
+                    "total_ms": 5069.57221031189,
+                    "cpu_utilization": 52.6,
+                    "gpu_utilization": 59
+                },
+                "forward::execution": {
+                    "num_iterations": 140,
+                    "total_ms": 10013.015985488892,
+                    "cpu_utilization": 52.5,
+                    "gpu_utilization": 55
+                },
+                "cleanup::memory_gpu::pre": 3314155520,
+                "cleanup::memory_cpu::pre": 59159453696,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59160477696,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59182542848,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59160477696
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59160477696,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59161116672,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59165753344,
+                "forward::memory_gpu::post": 6598295552,
+                "forward::memory_cpu::post": 59180986368,
+                "forward_warmup::execution": {
+                    "num_iterations": 31,
+                    "total_ms": 5068.081617355347,
+                    "cpu_utilization": 52.6,
+                    "gpu_utilization": 58
+                },
+                "forward::execution": {
+                    "num_iterations": 61,
+                    "total_ms": 10075.758457183838,
+                    "cpu_utilization": 55.5,
+                    "gpu_utilization": 67
+                },
+                "cleanup::memory_gpu::pre": 6598295552,
+                "cleanup::memory_cpu::pre": 59185299456,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59162292224,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59160477696,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59162292224
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59162292224,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59169759232,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59168239616,
+                "forward::memory_gpu::post": 2569666560,
+                "forward::memory_cpu::post": 59169656832,
+                "forward_warmup::execution": {
+                    "num_iterations": 134,
+                    "total_ms": 5037.501573562622,
+                    "cpu_utilization": 52.8,
+                    "gpu_utilization": 48
+                },
+                "forward::execution": {
+                    "num_iterations": 269,
+                    "total_ms": 10016.237497329712,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 45
+                },
+                "cleanup::memory_gpu::pre": 2569666560,
+                "cleanup::memory_cpu::pre": 59164553216,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59164782592,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59162292224,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59164782592
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59164782592,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59164323840,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59184283648,
+                "forward::memory_gpu::post": 5019140096,
+                "forward::memory_cpu::post": 59183767552,
+                "forward_warmup::execution": {
+                    "num_iterations": 37,
+                    "total_ms": 5135.59627532959,
+                    "cpu_utilization": 52.6,
+                    "gpu_utilization": 42
+                },
+                "forward::execution": {
+                    "num_iterations": 72,
+                    "total_ms": 10019.189596176147,
+                    "cpu_utilization": 52.3,
+                    "gpu_utilization": 46
+                },
+                "cleanup::memory_gpu::pre": 5019140096,
+                "cleanup::memory_cpu::pre": 59156774912,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59156193280,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59164782592,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59156193280
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59156193280,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59157450752,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59156877312,
+                "forward::memory_gpu::post": 9962127360,
+                "forward::memory_cpu::post": 59156877312,
+                "forward_warmup::execution": {
+                    "num_iterations": 17,
+                    "total_ms": 5183.184862136841,
+                    "cpu_utilization": 52.2,
+                    "gpu_utilization": 88
+                },
+                "forward::execution": {
+                    "num_iterations": 33,
+                    "total_ms": 10092.312335968018,
+                    "cpu_utilization": 52.5,
+                    "gpu_utilization": 42
+                },
+                "cleanup::memory_gpu::pre": 9962127360,
+                "cleanup::memory_cpu::pre": 59164127232,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59181129728,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59156193280,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59181129728
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59181129728,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59182592000,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59158835200,
+                "forward::memory_gpu::post": 3490316288,
+                "forward::memory_cpu::post": 59158761472,
+                "forward_warmup::execution": {
+                    "num_iterations": 65,
+                    "total_ms": 5018.581390380859,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 51
+                },
+                "forward::execution": {
+                    "num_iterations": 129,
+                    "total_ms": 10009.850263595581,
+                    "cpu_utilization": 52.4,
+                    "gpu_utilization": 53
+                },
+                "cleanup::memory_gpu::pre": 3490316288,
+                "cleanup::memory_cpu::pre": 59152019456,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59174727680,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59181129728,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59174727680
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59174727680,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59152433152,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59152433152,
+                "forward::memory_gpu::post": 8401846272,
+                "forward::memory_cpu::post": 59152433152,
+                "forward_warmup::execution": {
+                    "num_iterations": 18,
+                    "total_ms": 5029.016733169556,
+                    "cpu_utilization": 52.7,
+                    "gpu_utilization": 40
+                },
+                "forward::execution": {
+                    "num_iterations": 36,
+                    "total_ms": 10036.555528640747,
+                    "cpu_utilization": 52.2,
+                    "gpu_utilization": 49
+                },
+                "cleanup::memory_gpu::pre": 8401846272,
+                "cleanup::memory_cpu::pre": 59156127744,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59158528000,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59174727680,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59158528000
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59158528000,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59180429312,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59180785664,
+                "forward::memory_gpu::post": 18273140736,
+                "forward::memory_cpu::post": 59157024768,
+                "forward_warmup::execution": {
+                    "num_iterations": 9,
+                    "total_ms": 5497.981309890747,
+                    "cpu_utilization": 42.4,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 17,
+                    "total_ms": 10426.419973373413,
+                    "cpu_utilization": 42.9,
+                    "gpu_utilization": 96
+                },
+                "cleanup::memory_gpu::pre": 18273140736,
+                "cleanup::memory_cpu::pre": 59177873408,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59178106880,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59158528000,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59178106880
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59178106880,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59154554880,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59177213952,
+                "forward::memory_gpu::post": 5019140096,
+                "forward::memory_cpu::post": 59177213952,
+                "forward_warmup::execution": {
+                    "num_iterations": 31,
+                    "total_ms": 5098.690032958984,
+                    "cpu_utilization": 52.6,
+                    "gpu_utilization": 57
+                },
+                "forward::execution": {
+                    "num_iterations": 62,
+                    "total_ms": 10069.228172302246,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 46
+                },
+                "cleanup::memory_gpu::pre": 5019140096,
+                "cleanup::memory_cpu::pre": 59158773760,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59158634496,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59178106880,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59158634496
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59158634496,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59159638016,
+                "forward::memory_gpu::pre": 1632239616,
+                "forward::memory_cpu::pre": 59182358528,
+                "forward::memory_gpu::post": 15163064320,
+                "forward::memory_cpu::post": 59166990336,
+                "forward_warmup::execution": {
+                    "num_iterations": 9,
+                    "total_ms": 5054.893493652344,
+                    "cpu_utilization": 41.8,
+                    "gpu_utilization": 99
+                },
+                "forward::execution": {
+                    "num_iterations": 18,
+                    "total_ms": 10142.398118972778,
+                    "cpu_utilization": 41.8,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 15163064320,
+                "cleanup::memory_cpu::pre": 59165777920,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59178422272,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59158634496,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59178422272
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/small",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59178422272,
+                "init::memory_gpu::post": 1632239616,
+                "init::memory_cpu::post": 59154669568,
+                "cleanup::memory_gpu::pre": 22868000768,
+                "cleanup::memory_cpu::pre": 59148652544,
+                "cleanup::memory_gpu::post": 22868000768,
+                "cleanup::memory_cpu::post": 59148652544
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 22868000768,
+                "init::memory_cpu::pre": 59148652544,
+                "init::memory_gpu::post": 22868000768,
+                "init::memory_cpu::post": 59172843520,
+                "forward::memory_gpu::pre": 22868000768,
+                "forward::memory_cpu::pre": 59172843520,
+                "forward::memory_gpu::post": 22870097920,
+                "forward::memory_cpu::post": 59172843520,
+                "forward_warmup::execution": {
+                    "num_iterations": 457,
+                    "total_ms": 5004.307746887207,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 47
+                },
+                "forward::execution": {
+                    "num_iterations": 955,
+                    "total_ms": 10007.28440284729,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 53
+                },
+                "cleanup::memory_gpu::pre": 22870097920,
+                "cleanup::memory_cpu::pre": 59168497664,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59176779776,
+                "wrap::memory_gpu::pre": 22868000768,
+                "wrap::memory_cpu::pre": 59148652544,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59176779776
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59176779776,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59154829312,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59154829312,
+                "forward::memory_gpu::post": 2194276352,
+                "forward::memory_cpu::post": 59154829312,
+                "forward_warmup::execution": {
+                    "num_iterations": 325,
+                    "total_ms": 5015.636920928955,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 81
+                },
+                "forward::execution": {
+                    "num_iterations": 649,
+                    "total_ms": 10004.146814346313,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 81
+                },
+                "cleanup::memory_gpu::pre": 2194276352,
+                "cleanup::memory_cpu::pre": 59150241792,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59150233600,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59176779776,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59150233600
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59150233600,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59150282752,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59150282752,
+                "forward::memory_gpu::post": 2343174144,
+                "forward::memory_cpu::post": 59150282752,
+                "forward_warmup::execution": {
+                    "num_iterations": 145,
+                    "total_ms": 5001.924753189087,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 71
+                },
+                "forward::execution": {
+                    "num_iterations": 290,
+                    "total_ms": 10011.223316192627,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 81
+                },
+                "cleanup::memory_gpu::pre": 2477391872,
+                "cleanup::memory_cpu::pre": 59193397248,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59192881152,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59150233600,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59192881152
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59192881152,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59188051968,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59163783168,
+                "forward::memory_gpu::post": 2081030144,
+                "forward::memory_cpu::post": 59163783168,
+                "forward_warmup::execution": {
+                    "num_iterations": 359,
+                    "total_ms": 5011.095285415649,
+                    "cpu_utilization": 51.7,
+                    "gpu_utilization": 56
+                },
+                "forward::execution": {
+                    "num_iterations": 719,
+                    "total_ms": 10013.450622558594,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 53
+                },
+                "cleanup::memory_gpu::pre": 2081030144,
+                "cleanup::memory_cpu::pre": 59166265344,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59166523392,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59192881152,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59166523392
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59166523392,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59166470144,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59166470144,
+                "forward::memory_gpu::post": 2429157376,
+                "forward::memory_cpu::post": 59166470144,
+                "forward_warmup::execution": {
+                    "num_iterations": 165,
+                    "total_ms": 5010.988235473633,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 75
+                },
+                "forward::execution": {
+                    "num_iterations": 331,
+                    "total_ms": 10024.810552597046,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 76
+                },
+                "cleanup::memory_gpu::pre": 2429157376,
+                "cleanup::memory_cpu::pre": 59187961856,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59187961856,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59166523392,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59187961856
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59187961856,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59164278784,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59164278784,
+                "forward::memory_gpu::post": 2840199168,
+                "forward::memory_cpu::post": 59164278784,
+                "forward_warmup::execution": {
+                    "num_iterations": 73,
+                    "total_ms": 5055.466175079346,
+                    "cpu_utilization": 52.2,
+                    "gpu_utilization": 69
+                },
+                "forward::execution": {
+                    "num_iterations": 144,
+                    "total_ms": 10003.517627716064,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 71
+                },
+                "cleanup::memory_gpu::pre": 3108634624,
+                "cleanup::memory_cpu::pre": 59161120768,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59161120768,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59187961856,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59161120768
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59161120768,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59161325568,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59161841664,
+                "forward::memory_gpu::post": 2194276352,
+                "forward::memory_cpu::post": 59167518720,
+                "forward_warmup::execution": {
+                    "num_iterations": 288,
+                    "total_ms": 5007.7314376831055,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 70
+                },
+                "forward::execution": {
+                    "num_iterations": 578,
+                    "total_ms": 10014.355182647705,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 68
+                },
+                "cleanup::memory_gpu::pre": 2194276352,
+                "cleanup::memory_cpu::pre": 59178754048,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59178754048,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59161120768,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59178754048
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59178754048,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59154837504,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59154821120,
+                "forward::memory_gpu::post": 2735341568,
+                "forward::memory_cpu::post": 59154821120,
+                "forward_warmup::execution": {
+                    "num_iterations": 84,
+                    "total_ms": 5026.314973831177,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 76
+                },
+                "forward::execution": {
+                    "num_iterations": 168,
+                    "total_ms": 10044.942378997803,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 75
+                },
+                "cleanup::memory_gpu::pre": 3003777024,
+                "cleanup::memory_cpu::pre": 59159916544,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59160174592,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59178754048,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59160174592
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59160174592,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59169026048,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59184754688,
+                "forward::memory_gpu::post": 4589223936,
+                "forward::memory_cpu::post": 59184754688,
+                "forward_warmup::execution": {
+                    "num_iterations": 35,
+                    "total_ms": 5047.407627105713,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 83
+                },
+                "forward::execution": {
+                    "num_iterations": 70,
+                    "total_ms": 10086.817979812622,
+                    "cpu_utilization": 52.9,
+                    "gpu_utilization": 73
+                },
+                "cleanup::memory_gpu::pre": 5205786624,
+                "cleanup::memory_cpu::pre": 59181780992,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59182772224,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59160174592,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59182772224
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59182772224,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59158978560,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59158978560,
+                "forward::memory_gpu::post": 2701787136,
+                "forward::memory_cpu::post": 59159207936,
+                "forward_warmup::execution": {
+                    "num_iterations": 162,
+                    "total_ms": 5008.957624435425,
+                    "cpu_utilization": 51.7,
+                    "gpu_utilization": 70
+                },
+                "forward::execution": {
+                    "num_iterations": 324,
+                    "total_ms": 10009.51862335205,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 68
+                },
+                "cleanup::memory_gpu::pre": 2701787136,
+                "cleanup::memory_cpu::pre": 59160129536,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59159916544,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59182772224,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59159916544
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59159916544,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59162177536,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59164729344,
+                "forward::memory_gpu::post": 3853123584,
+                "forward::memory_cpu::post": 59186884608,
+                "forward_warmup::execution": {
+                    "num_iterations": 42,
+                    "total_ms": 5068.8276290893555,
+                    "cpu_utilization": 52.4,
+                    "gpu_utilization": 78
+                },
+                "forward::execution": {
+                    "num_iterations": 83,
+                    "total_ms": 10007.61866569519,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 72
+                },
+                "cleanup::memory_gpu::pre": 4362731520,
+                "cleanup::memory_cpu::pre": 59185647616,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59185647616,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59159916544,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59185647616
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59185647616,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59186872320,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59163607040,
+                "forward::memory_gpu::post": 6225002496,
+                "forward::memory_cpu::post": 59163291648,
+                "forward_warmup::execution": {
+                    "num_iterations": 18,
+                    "total_ms": 5164.376497268677,
+                    "cpu_utilization": 50.0,
+                    "gpu_utilization": 83
+                },
+                "forward::execution": {
+                    "num_iterations": 35,
+                    "total_ms": 10011.160612106323,
+                    "cpu_utilization": 49.9,
+                    "gpu_utilization": 75
+                },
+                "cleanup::memory_gpu::pre": 7374241792,
+                "cleanup::memory_cpu::pre": 59169546240,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59168485376,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59185647616,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59168485376
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59168485376,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59168534528,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59168534528,
+                "forward::memory_gpu::post": 2735341568,
+                "forward::memory_cpu::post": 59168534528,
+                "forward_warmup::execution": {
+                    "num_iterations": 86,
+                    "total_ms": 5036.429882049561,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 68
+                },
+                "forward::execution": {
+                    "num_iterations": 171,
+                    "total_ms": 10027.233362197876,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 66
+                },
+                "cleanup::memory_gpu::pre": 3003777024,
+                "cleanup::memory_cpu::pre": 59160899584,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59184340992,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59168485376,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59184340992
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59184340992,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59168264192,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59184553984,
+                "forward::memory_gpu::post": 5717491712,
+                "forward::memory_cpu::post": 59161554944,
+                "forward_warmup::execution": {
+                    "num_iterations": 21,
+                    "total_ms": 5091.8824672698975,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 69
+                },
+                "forward::execution": {
+                    "num_iterations": 42,
+                    "total_ms": 10187.878847122192,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 69
+                },
+                "cleanup::memory_gpu::pre": 6189350912,
+                "cleanup::memory_cpu::pre": 59166171136,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59166916608,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59184340992,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59166916608
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59166916608,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59168612352,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59190697984,
+                "forward::memory_gpu::post": 10740170752,
+                "forward::memory_cpu::post": 59181490176,
+                "forward_warmup::execution": {
+                    "num_iterations": 10,
+                    "total_ms": 5220.90482711792,
+                    "cpu_utilization": 44.2,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 20,
+                    "total_ms": 10504.643201828003,
+                    "cpu_utilization": 44.0,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 11803426816,
+                "cleanup::memory_cpu::pre": 59174420480,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59175424000,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59166916608,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59175424000
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59175424000,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59175501824,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59179114496,
+                "forward::memory_gpu::post": 3853123584,
+                "forward::memory_cpu::post": 59197431808,
+                "forward_warmup::execution": {
+                    "num_iterations": 43,
+                    "total_ms": 5061.5198612213135,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 70
+                },
+                "forward::execution": {
+                    "num_iterations": 85,
+                    "total_ms": 10003.279447555542,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 74
+                },
+                "cleanup::memory_gpu::pre": 4358537216,
+                "cleanup::memory_cpu::pre": 59194974208,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59170828288,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59175424000,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59170828288
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59170828288,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59172999168,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59172728832,
+                "forward::memory_gpu::post": 9723052032,
+                "forward::memory_cpu::post": 59172728832,
+                "forward_warmup::execution": {
+                    "num_iterations": 12,
+                    "total_ms": 5414.698600769043,
+                    "cpu_utilization": 38.0,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 23,
+                    "total_ms": 10382.43293762207,
+                    "cpu_utilization": 37.9,
+                    "gpu_utilization": 98
+                },
+                "cleanup::memory_gpu::pre": 10666770432,
+                "cleanup::memory_cpu::pre": 59196157952,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59196616704,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59170828288,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59196616704
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59196616704,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59173806080,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59197153280,
+                "forward::memory_gpu::post": 19760021504,
+                "forward::memory_cpu::post": 59168493568,
+                "forward_warmup::execution": {
+                    "num_iterations": 6,
+                    "total_ms": 5849.5495319366455,
+                    "cpu_utilization": 31.8,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 11,
+                    "total_ms": 10745.529890060425,
+                    "cpu_utilization": 31.8,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 21884436480,
+                "cleanup::memory_cpu::pre": 59188842496,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59189997568,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59196616704,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59189997568
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59189997568,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59168006144,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59167064064,
+                "forward::memory_gpu::post": 6784942080,
+                "forward::memory_cpu::post": 59166969856,
+                "forward_warmup::execution": {
+                    "num_iterations": 21,
+                    "total_ms": 5109.916210174561,
+                    "cpu_utilization": 47.6,
+                    "gpu_utilization": 61
+                },
+                "forward::execution": {
+                    "num_iterations": 42,
+                    "total_ms": 10217.023849487305,
+                    "cpu_utilization": 47.5,
+                    "gpu_utilization": 63
+                },
+                "cleanup::memory_gpu::pre": 6784942080,
+                "cleanup::memory_cpu::pre": 59176730624,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59189633024,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59189997568,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59189633024
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59189633024,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59168006144,
+                "forward::memory_gpu::pre": 1701445632,
+                "forward::memory_cpu::pre": 59169435648,
+                "forward::memory_gpu::post": 21997682688,
+                "forward::memory_cpu::post": 59192336384,
+                "forward_warmup::execution": {
+                    "num_iterations": 6,
+                    "total_ms": 5124.162197113037,
+                    "cpu_utilization": 29.0,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 12,
+                    "total_ms": 10271.819829940796,
+                    "cpu_utilization": 29.1,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 21997682688,
+                "cleanup::memory_cpu::pre": 59203579904,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59205439488,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59189633024,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59205439488
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/medium",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59205439488,
+                "init::memory_gpu::post": 1701445632,
+                "init::memory_cpu::post": 59184836608,
+                "cleanup::memory_gpu::pre": 25061621760,
+                "cleanup::memory_cpu::pre": 59164753920,
+                "cleanup::memory_gpu::post": 25061621760,
+                "cleanup::memory_cpu::post": 59164753920
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 25061621760,
+                "init::memory_cpu::pre": 59164753920,
+                "init::memory_gpu::post": 25076301824,
+                "init::memory_cpu::post": 59193823232,
+                "forward::memory_gpu::pre": 25076301824,
+                "forward::memory_cpu::pre": 59193823232,
+                "forward::memory_gpu::post": 25082593280,
+                "forward::memory_cpu::post": 59193823232,
+                "forward_warmup::execution": {
+                    "num_iterations": 381,
+                    "total_ms": 5012.892007827759,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 70
+                },
+                "forward::execution": {
+                    "num_iterations": 762,
+                    "total_ms": 10014.4681930542,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 71
+                },
+                "cleanup::memory_gpu::pre": 25082593280,
+                "cleanup::memory_cpu::pre": 59188465664,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59183812608,
+                "wrap::memory_gpu::pre": 25061621760,
+                "wrap::memory_cpu::pre": 59164753920,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59183812608
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59183812608,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59160739840,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59160739840,
+                "forward::memory_gpu::post": 2433351680,
+                "forward::memory_cpu::post": 59160739840,
+                "forward_warmup::execution": {
+                    "num_iterations": 207,
+                    "total_ms": 5012.157917022705,
+                    "cpu_utilization": 51.7,
+                    "gpu_utilization": 87
+                },
+                "forward::execution": {
+                    "num_iterations": 413,
+                    "total_ms": 10002.926111221313,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 87
+                },
+                "cleanup::memory_gpu::pre": 2433351680,
+                "cleanup::memory_cpu::pre": 59172409344,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59172864000,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59183812608,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59172864000
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59172864000,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59197067264,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59197067264,
+                "forward::memory_gpu::post": 2689204224,
+                "forward::memory_cpu::post": 59197067264,
+                "forward_warmup::execution": {
+                    "num_iterations": 97,
+                    "total_ms": 5025.869131088257,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 81
+                },
+                "forward::execution": {
+                    "num_iterations": 197,
+                    "total_ms": 10006.391763687134,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 89
+                },
+                "cleanup::memory_gpu::pre": 2823421952,
+                "cleanup::memory_cpu::pre": 59173232640,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59173232640,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59172864000,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59173232640
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59173232640,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59173625856,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59173625856,
+                "forward::memory_gpu::post": 2179596288,
+                "forward::memory_cpu::post": 59173625856,
+                "forward_warmup::execution": {
+                    "num_iterations": 288,
+                    "total_ms": 5015.70987701416,
+                    "cpu_utilization": 51.7,
+                    "gpu_utilization": 71
+                },
+                "forward::execution": {
+                    "num_iterations": 570,
+                    "total_ms": 10002.32744216919,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 72
+                },
+                "cleanup::memory_gpu::pre": 2179596288,
+                "cleanup::memory_cpu::pre": 59196219392,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59196801024,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59173232640,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59196801024
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59196801024,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59172237312,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59172237312,
+                "forward::memory_gpu::post": 2640969728,
+                "forward::memory_cpu::post": 59172237312,
+                "forward_warmup::execution": {
+                    "num_iterations": 111,
+                    "total_ms": 5034.399747848511,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 86
+                },
+                "forward::execution": {
+                    "num_iterations": 221,
+                    "total_ms": 10003.506183624268,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 83
+                },
+                "cleanup::memory_gpu::pre": 2640969728,
+                "cleanup::memory_cpu::pre": 59177058304,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59177803776,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59196801024,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59177803776
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59177803776,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59184967680,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59200667648,
+                "forward::memory_gpu::post": 3549036544,
+                "forward::memory_cpu::post": 59202146304,
+                "forward_warmup::execution": {
+                    "num_iterations": 51,
+                    "total_ms": 5059.106826782227,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 80
+                },
+                "forward::execution": {
+                    "num_iterations": 101,
+                    "total_ms": 10071.991920471191,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 80
+                },
+                "cleanup::memory_gpu::pre": 3549036544,
+                "cleanup::memory_cpu::pre": 59198701568,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59199905792,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59177803776,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59199905792
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59199905792,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59176390656,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59176390656,
+                "forward::memory_gpu::post": 2338979840,
+                "forward::memory_cpu::post": 59176390656,
+                "forward_warmup::execution": {
+                    "num_iterations": 192,
+                    "total_ms": 5004.135370254517,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 81
+                },
+                "forward::execution": {
+                    "num_iterations": 384,
+                    "total_ms": 10011.900901794434,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 81
+                },
+                "cleanup::memory_gpu::pre": 2338979840,
+                "cleanup::memory_cpu::pre": 59177545728,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59178250240,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59199905792,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59178250240
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59178250240,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59201699840,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59201699840,
+                "forward::memory_gpu::post": 3486121984,
+                "forward::memory_cpu::post": 59202650112,
+                "forward_warmup::execution": {
+                    "num_iterations": 57,
+                    "total_ms": 5063.885927200317,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 84
+                },
+                "forward::execution": {
+                    "num_iterations": 113,
+                    "total_ms": 10024.021625518799,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 85
+                },
+                "cleanup::memory_gpu::pre": 3486121984,
+                "cleanup::memory_cpu::pre": 59195006976,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59194658816,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59178250240,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59194658816
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59194658816,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59171291136,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59171520512,
+                "forward::memory_gpu::post": 13422428160,
+                "forward::memory_cpu::post": 59171319808,
+                "forward_warmup::execution": {
+                    "num_iterations": 21,
+                    "total_ms": 5151.203870773315,
+                    "cpu_utilization": 49.6,
+                    "gpu_utilization": 83
+                },
+                "forward::execution": {
+                    "num_iterations": 41,
+                    "total_ms": 10049.301862716675,
+                    "cpu_utilization": 49.5,
+                    "gpu_utilization": 88
+                },
+                "cleanup::memory_gpu::pre": 13422428160,
+                "cleanup::memory_cpu::pre": 59174371328,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59193643008,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59194658816,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59193643008
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59193643008,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59191480320,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59167723520,
+                "forward::memory_gpu::post": 3131703296,
+                "forward::memory_cpu::post": 59167723520,
+                "forward_warmup::execution": {
+                    "num_iterations": 108,
+                    "total_ms": 5017.771244049072,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 76
+                },
+                "forward::execution": {
+                    "num_iterations": 216,
+                    "total_ms": 10003.91173362732,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 78
+                },
+                "cleanup::memory_gpu::pre": 3131703296,
+                "cleanup::memory_cpu::pre": 59172364288,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59171803136,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59193643008,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59171803136
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59171803136,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59174297600,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59173167104,
+                "forward::memory_gpu::post": 5990121472,
+                "forward::memory_cpu::post": 59198357504,
+                "forward_warmup::execution": {
+                    "num_iterations": 30,
+                    "total_ms": 5148.386716842651,
+                    "cpu_utilization": 52.3,
+                    "gpu_utilization": 84
+                },
+                "forward::execution": {
+                    "num_iterations": 59,
+                    "total_ms": 10112.921476364136,
+                    "cpu_utilization": 52.2,
+                    "gpu_utilization": 84
+                },
+                "cleanup::memory_gpu::pre": 5990121472,
+                "cleanup::memory_cpu::pre": 59203174400,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59179089920,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59171803136,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59179089920
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59179089920,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59179024384,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59179024384,
+                "forward::memory_gpu::post": 15452471296,
+                "forward::memory_cpu::post": 59179024384,
+                "forward_warmup::execution": {
+                    "num_iterations": 13,
+                    "total_ms": 5312.833786010742,
+                    "cpu_utilization": 35.5,
+                    "gpu_utilization": 79
+                },
+                "forward::execution": {
+                    "num_iterations": 25,
+                    "total_ms": 10226.140260696411,
+                    "cpu_utilization": 35.6,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 15452471296,
+                "cleanup::memory_cpu::pre": 59209068544,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59184021504,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59179089920,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59184021504
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59184021504,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59180945408,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59180945408,
+                "forward::memory_gpu::post": 3716808704,
+                "forward::memory_cpu::post": 59180945408,
+                "forward_warmup::execution": {
+                    "num_iterations": 63,
+                    "total_ms": 5032.062530517578,
+                    "cpu_utilization": 52.3,
+                    "gpu_utilization": 76
+                },
+                "forward::execution": {
+                    "num_iterations": 126,
+                    "total_ms": 10060.470819473267,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 71
+                },
+                "cleanup::memory_gpu::pre": 3716808704,
+                "cleanup::memory_cpu::pre": 59185643520,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59191320576,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59184021504,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59191320576
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59191320576,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59186659328,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59186425856,
+                "forward::memory_gpu::post": 9689497600,
+                "forward::memory_cpu::post": 59186655232,
+                "forward_warmup::execution": {
+                    "num_iterations": 17,
+                    "total_ms": 5133.829116821289,
+                    "cpu_utilization": 44.7,
+                    "gpu_utilization": 69
+                },
+                "forward::execution": {
+                    "num_iterations": 34,
+                    "total_ms": 10270.969152450562,
+                    "cpu_utilization": 45.0,
+                    "gpu_utilization": 93
+                },
+                "cleanup::memory_gpu::pre": 9689497600,
+                "cleanup::memory_cpu::pre": 59196387328,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59195711488,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59191320576,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59195711488
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59195711488,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59195240448,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59195998208,
+                "forward::memory_gpu::post": 19525140480,
+                "forward::memory_cpu::post": 59198672896,
+                "forward_warmup::execution": {
+                    "num_iterations": 8,
+                    "total_ms": 5369.92335319519,
+                    "cpu_utilization": 28.4,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 15,
+                    "total_ms": 10054.536581039429,
+                    "cpu_utilization": 28.6,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 19525140480,
+                "cleanup::memory_cpu::pre": 59243679744,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59220443136,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59195711488,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59220443136
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59220443136,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59197558784,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59198447616,
+                "forward::memory_gpu::post": 5889458176,
+                "forward::memory_cpu::post": 59199963136,
+                "forward_warmup::execution": {
+                    "num_iterations": 32,
+                    "total_ms": 5112.3034954071045,
+                    "cpu_utilization": 52.3,
+                    "gpu_utilization": 80
+                },
+                "forward::execution": {
+                    "num_iterations": 64,
+                    "total_ms": 10126.40905380249,
+                    "cpu_utilization": 52.3,
+                    "gpu_utilization": 77
+                },
+                "cleanup::memory_gpu::pre": 5889458176,
+                "cleanup::memory_cpu::pre": 59205701632,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59213332480,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59220443136,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59213332480
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59213332480,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59204026368,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59204464640,
+                "forward::memory_gpu::post": 17551720448,
+                "forward::memory_cpu::post": 59205361664,
+                "forward_warmup::execution": {
+                    "num_iterations": 9,
+                    "total_ms": 5452.40592956543,
+                    "cpu_utilization": 29.4,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 17,
+                    "total_ms": 10272.933959960938,
+                    "cpu_utilization": 29.7,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 17551720448,
+                "cleanup::memory_cpu::pre": 59198025728,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59175817216,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59213332480,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59175817216
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59175817216,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59183767552,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59183374336,
+                "forward::memory_gpu::post": 23406968832,
+                "forward::memory_cpu::post": 59184476160,
+                "forward_warmup::execution": {
+                    "num_iterations": 4,
+                    "total_ms": 5326.544284820557,
+                    "cpu_utilization": 22.1,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 8,
+                    "total_ms": 10568.354368209839,
+                    "cpu_utilization": 21.6,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 24822546432,
+                "cleanup::memory_cpu::pre": 59180687360,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59175256064,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59176333312,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59175256064
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59175256064,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59151114240,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59151667200,
+                "forward::memory_gpu::post": 8741584896,
+                "forward::memory_cpu::post": 59151667200,
+                "forward_warmup::execution": {
+                    "num_iterations": 16,
+                    "total_ms": 5191.664934158325,
+                    "cpu_utilization": 36.4,
+                    "gpu_utilization": 60
+                },
+                "forward::execution": {
+                    "num_iterations": 31,
+                    "total_ms": 10043.664693832397,
+                    "cpu_utilization": 36.6,
+                    "gpu_utilization": 97
+                },
+                "cleanup::memory_gpu::pre": 8741584896,
+                "cleanup::memory_cpu::pre": 59154214912,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59158028288,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59175256064,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59158028288
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59158028288,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59157876736,
+                "forward::memory_gpu::pre": 1806303232,
+                "forward::memory_cpu::pre": 59181875200,
+                "forward::memory_gpu::post": 17232953344,
+                "forward::memory_cpu::post": 59155759104,
+                "forward_warmup::execution": {
+                    "num_iterations": 5,
+                    "total_ms": 6078.411817550659,
+                    "cpu_utilization": 21.6,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 9,
+                    "total_ms": 10823.002576828003,
+                    "cpu_utilization": 21.2,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 25101467648,
+                "cleanup::memory_cpu::pre": 59155562496,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59144691712,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59158028288,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59144691712
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/large",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59144691712,
+                "init::memory_gpu::post": 1806303232,
+                "init::memory_cpu::post": 59144933376,
+                "cleanup::memory_gpu::pre": 17379753984,
+                "cleanup::memory_cpu::pre": 59156377600,
+                "cleanup::memory_gpu::post": 17379753984,
+                "cleanup::memory_cpu::post": 59132878848
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/xlarge",
+            "profile_data": {
+                "init::memory_gpu::pre": 17379753984,
+                "init::memory_cpu::pre": 59130814464,
+                "init::memory_gpu::post": 17383948288,
+                "init::memory_cpu::post": 59130945536,
+                "forward::memory_gpu::pre": 17383948288,
+                "forward::memory_cpu::pre": 59130945536,
+                "forward::memory_gpu::post": 17392336896,
+                "forward::memory_cpu::post": 59130945536,
+                "forward_warmup::execution": {
+                    "num_iterations": 230,
+                    "total_ms": 5016.765594482422,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 89
+                },
+                "forward::execution": {
+                    "num_iterations": 464,
+                    "total_ms": 10013.250589370728,
+                    "cpu_utilization": 51.7,
+                    "gpu_utilization": 89
+                },
+                "cleanup::memory_gpu::pre": 17392336896,
+                "cleanup::memory_cpu::pre": 59138527232,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59144921088,
+                "wrap::memory_gpu::pre": 17379753984,
+                "wrap::memory_cpu::pre": 59130814464,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59144921088
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/xlarge",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59144921088,
+                "init::memory_gpu::post": 1992949760,
+                "init::memory_cpu::post": 59139399680,
+                "forward::memory_gpu::pre": 1992949760,
+                "forward::memory_cpu::pre": 59139399680,
+                "forward::memory_gpu::post": 2645164032,
+                "forward::memory_cpu::post": 59139399680,
+                "forward_warmup::execution": {
+                    "num_iterations": 122,
+                    "total_ms": 5009.539604187012,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 92
+                },
+                "forward::execution": {
+                    "num_iterations": 244,
+                    "total_ms": 10037.158727645874,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 92
+                },
+                "cleanup::memory_gpu::pre": 2645164032,
+                "cleanup::memory_cpu::pre": 59137708032,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59137708032,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59144921088,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59137708032
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/xlarge",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59137708032,
+                "init::memory_gpu::post": 1992949760,
+                "init::memory_cpu::post": 59159425024,
+                "forward::memory_gpu::pre": 1992949760,
+                "forward::memory_cpu::pre": 59159994368,
+                "forward::memory_gpu::post": 2957639680,
+                "forward::memory_cpu::post": 59161120768,
+                "forward_warmup::execution": {
+                    "num_iterations": 59,
+                    "total_ms": 5061.123371124268,
+                    "cpu_utilization": 51.7,
+                    "gpu_utilization": 90
+                },
+                "forward::execution": {
+                    "num_iterations": 118,
+                    "total_ms": 10051.748275756836,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 90
+                },
+                "cleanup::memory_gpu::pre": 3203006464,
+                "cleanup::memory_cpu::pre": 59136319488,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59136319488,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59137708032,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59136319488
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/xlarge",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59136319488,
+                "init::memory_gpu::post": 1992949760,
+                "init::memory_cpu::post": 59136311296,
+                "forward::memory_gpu::pre": 1992949760,
+                "forward::memory_cpu::pre": 59136311296,
+                "forward::memory_gpu::post": 2343174144,
+                "forward::memory_cpu::post": 59136311296,
+                "forward_warmup::execution": {
+                    "num_iterations": 145,
+                    "total_ms": 5006.994009017944,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 92
+                },
+                "forward::execution": {
+                    "num_iterations": 290,
+                    "total_ms": 10022.453546524048,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 91
+                },
+                "cleanup::memory_gpu::pre": 2343174144,
+                "cleanup::memory_cpu::pre": 59159830528,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59162169344,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59136319488,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59162169344
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/xlarge",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59162169344,
+                "init::memory_gpu::post": 1992949760,
+                "init::memory_cpu::post": 59139100672,
+                "forward::memory_gpu::pre": 1992949760,
+                "forward::memory_cpu::pre": 59139100672,
+                "forward::memory_gpu::post": 2852782080,
+                "forward::memory_cpu::post": 59139100672,
+                "forward_warmup::execution": {
+                    "num_iterations": 60,
+                    "total_ms": 5034.30700302124,
+                    "cpu_utilization": 51.7,
+                    "gpu_utilization": 90
+                },
+                "forward::execution": {
+                    "num_iterations": 120,
+                    "total_ms": 10037.744998931885,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 92
+                },
+                "cleanup::memory_gpu::pre": 3085565952,
+                "cleanup::memory_cpu::pre": 59138953216,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59138953216,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59162169344,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59138953216
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/xlarge",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59138953216,
+                "init::memory_gpu::post": 1992949760,
+                "init::memory_cpu::post": 59136184320,
+                "forward::memory_gpu::pre": 1992949760,
+                "forward::memory_cpu::pre": 59136184320,
+                "forward::memory_gpu::post": 3905552384,
+                "forward::memory_cpu::post": 59136442368,
+                "forward_warmup::execution": {
+                    "num_iterations": 28,
+                    "total_ms": 5047.255992889404,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 91
+                },
+                "forward::execution": {
+                    "num_iterations": 56,
+                    "total_ms": 10092.174291610718,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 86
+                },
+                "cleanup::memory_gpu::pre": 4127850496,
+                "cleanup::memory_cpu::pre": 59137667072,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59138666496,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59138953216,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59138666496
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/xlarge",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59138666496,
+                "init::memory_gpu::post": 1992949760,
+                "init::memory_cpu::post": 59160317952,
+                "forward::memory_gpu::pre": 1992949760,
+                "forward::memory_cpu::pre": 59160317952,
+                "forward::memory_gpu::post": 2645164032,
+                "forward::memory_cpu::post": 59160317952,
+                "forward_warmup::execution": {
+                    "num_iterations": 103,
+                    "total_ms": 5006.055116653442,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 90
+                },
+                "forward::execution": {
+                    "num_iterations": 206,
+                    "total_ms": 10047.21188545227,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 90
+                },
+                "cleanup::memory_gpu::pre": 2645164032,
+                "cleanup::memory_cpu::pre": 59136180224,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59135926272,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59138666496,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59135926272
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/xlarge",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59135926272,
+                "init::memory_gpu::post": 1992949760,
+                "init::memory_cpu::post": 59145986048,
+                "forward::memory_gpu::pre": 1992949760,
+                "forward::memory_cpu::pre": 59159146496,
+                "forward::memory_gpu::post": 3830054912,
+                "forward::memory_cpu::post": 59159334912,
+                "forward_warmup::execution": {
+                    "num_iterations": 32,
+                    "total_ms": 5044.21067237854,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 92
+                },
+                "forward::execution": {
+                    "num_iterations": 64,
+                    "total_ms": 10072.438716888428,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 92
+                },
+                "cleanup::memory_gpu::pre": 3830054912,
+                "cleanup::memory_cpu::pre": 59150487552,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59163648000,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59135926272,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59163648000
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/xlarge",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59163648000,
+                "init::memory_gpu::post": 1992949760,
+                "init::memory_cpu::post": 59141722112,
+                "forward::memory_gpu::pre": 1992949760,
+                "forward::memory_cpu::pre": 59141722112,
+                "forward::memory_gpu::post": 10838736896,
+                "forward::memory_cpu::post": 59162882048,
+                "forward_warmup::execution": {
+                    "num_iterations": 13,
+                    "total_ms": 5003.114461898804,
+                    "cpu_utilization": 33.1,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 26,
+                    "total_ms": 10007.453203201294,
+                    "cpu_utilization": 32.9,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 10838736896,
+                "cleanup::memory_cpu::pre": 59144691712,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59151233024,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59163648000,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59151233024
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/xlarge",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59151749120,
+                "init::memory_gpu::post": 1992949760,
+                "init::memory_cpu::post": 59142094848,
+                "forward::memory_gpu::pre": 1992949760,
+                "forward::memory_cpu::pre": 59142094848,
+                "forward::memory_gpu::post": 3611951104,
+                "forward::memory_cpu::post": 59142352896,
+                "forward_warmup::execution": {
+                    "num_iterations": 76,
+                    "total_ms": 5002.6679039001465,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 85
+                },
+                "forward::execution": {
+                    "num_iterations": 153,
+                    "total_ms": 10020.753145217896,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 84
+                },
+                "cleanup::memory_gpu::pre": 3611951104,
+                "cleanup::memory_cpu::pre": 59160453120,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59165614080,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59151749120,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59165614080
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/xlarge",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59165614080,
+                "init::memory_gpu::post": 1992949760,
+                "init::memory_cpu::post": 59159371776,
+                "forward::memory_gpu::pre": 1992949760,
+                "forward::memory_cpu::pre": 59159371776,
+                "forward::memory_gpu::post": 7168720896,
+                "forward::memory_cpu::post": 59159371776,
+                "forward_warmup::execution": {
+                    "num_iterations": 18,
+                    "total_ms": 5023.974418640137,
+                    "cpu_utilization": 43.6,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 36,
+                    "total_ms": 10078.088998794556,
+                    "cpu_utilization": 43.6,
+                    "gpu_utilization": 84
+                },
+                "cleanup::memory_gpu::pre": 7168720896,
+                "cleanup::memory_cpu::pre": 59159343104,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59159343104,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59165614080,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59159343104
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/xlarge",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59159343104,
+                "init::memory_gpu::post": 1992949760,
+                "init::memory_cpu::post": 59181416448,
+                "forward::memory_gpu::pre": 1992949760,
+                "forward::memory_cpu::pre": 59158974464,
+                "forward::memory_gpu::post": 15599271936,
+                "forward::memory_cpu::post": 59159101440,
+                "forward_warmup::execution": {
+                    "num_iterations": 9,
+                    "total_ms": 5549.636602401733,
+                    "cpu_utilization": 28.5,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 17,
+                    "total_ms": 10490.484714508057,
+                    "cpu_utilization": 28.1,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 15599271936,
+                "cleanup::memory_cpu::pre": 59158351872,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59179765760,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59159343104,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59179765760
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/xlarge",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59179765760,
+                "init::memory_gpu::post": 1992949760,
+                "init::memory_cpu::post": 59157856256,
+                "forward::memory_gpu::pre": 1992949760,
+                "forward::memory_cpu::pre": 59157856256,
+                "forward::memory_gpu::post": 4153016320,
+                "forward::memory_cpu::post": 59157856256,
+                "forward_warmup::execution": {
+                    "num_iterations": 44,
+                    "total_ms": 5112.524747848511,
+                    "cpu_utilization": 51.7,
+                    "gpu_utilization": 81
+                },
+                "forward::execution": {
+                    "num_iterations": 86,
+                    "total_ms": 10008.477210998535,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 88
+                },
+                "cleanup::memory_gpu::pre": 4153016320,
+                "cleanup::memory_cpu::pre": 59213000704,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59212988416,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59179765760,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59212988416
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/xlarge",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59212988416,
+                "init::memory_gpu::post": 1992949760,
+                "init::memory_cpu::post": 59197796352,
+                "forward::memory_gpu::pre": 1992949760,
+                "forward::memory_cpu::pre": 59198803968,
+                "forward::memory_gpu::post": 10549329920,
+                "forward::memory_cpu::post": 59224772608,
+                "forward_warmup::execution": {
+                    "num_iterations": 12,
+                    "total_ms": 5333.593368530273,
+                    "cpu_utilization": 33.0,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 23,
+                    "total_ms": 10218.067169189453,
+                    "cpu_utilization": 35.3,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 10549329920,
+                "cleanup::memory_cpu::pre": 59338719232,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59315724288,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59212988416,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59315724288
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/xlarge",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59315724288,
+                "init::memory_gpu::post": 1992949760,
+                "init::memory_cpu::post": 59316838400,
+                "forward::memory_gpu::pre": 1992949760,
+                "forward::memory_cpu::pre": 59316260864,
+                "forward::memory_gpu::post": 21217542144,
+                "forward::memory_cpu::post": 59314765824,
+                "forward_warmup::execution": {
+                    "num_iterations": 6,
+                    "total_ms": 5918.314456939697,
+                    "cpu_utilization": 24.8,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 11,
+                    "total_ms": 10888.009548187256,
+                    "cpu_utilization": 27.8,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 21217542144,
+                "cleanup::memory_cpu::pre": 59483766784,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59460530176,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59315724288,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59460530176
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/xlarge",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59460530176,
+                "init::memory_gpu::post": 1992949760,
+                "init::memory_cpu::post": 59461238784,
+                "forward::memory_gpu::pre": 1992949760,
+                "forward::memory_cpu::pre": 59461238784,
+                "forward::memory_gpu::post": 6417940480,
+                "forward::memory_cpu::post": 59461468160,
+                "forward_warmup::execution": {
+                    "num_iterations": 22,
+                    "total_ms": 5049.190998077393,
+                    "cpu_utilization": 45.4,
+                    "gpu_utilization": 80
+                },
+                "forward::execution": {
+                    "num_iterations": 44,
+                    "total_ms": 10085.038900375366,
+                    "cpu_utilization": 45.5,
+                    "gpu_utilization": 93
+                },
+                "cleanup::memory_gpu::pre": 6417940480,
+                "cleanup::memory_cpu::pre": 59491700736,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59469369344,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59460530176,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59469369344
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/xlarge",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59469369344,
+                "init::memory_gpu::post": 1992949760,
+                "init::memory_cpu::post": 59466735616,
+                "forward::memory_gpu::pre": 1992949760,
+                "forward::memory_cpu::pre": 59467276288,
+                "forward::memory_gpu::post": 19076349952,
+                "forward::memory_cpu::post": 59497304064,
+                "forward_warmup::execution": {
+                    "num_iterations": 6,
+                    "total_ms": 5312.483549118042,
+                    "cpu_utilization": 20.8,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 12,
+                    "total_ms": 10648.051023483276,
+                    "cpu_utilization": 20.9,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 19076349952,
+                "cleanup::memory_cpu::pre": 59480694784,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59479834624,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59469369344,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59479834624
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/xlarge",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59479834624,
+                "init::memory_gpu::post": 1992949760,
+                "init::memory_cpu::post": 59478290432,
+                "cleanup::memory_gpu::pre": 24291966976,
+                "cleanup::memory_cpu::pre": 59505807360,
+                "cleanup::memory_gpu::post": 24291966976,
+                "cleanup::memory_cpu::post": 59482882048
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 24291966976,
+                "init::memory_cpu::pre": 59482882048,
+                "init::memory_gpu::post": 24291966976,
+                "init::memory_cpu::post": 59484168192,
+                "forward::memory_gpu::pre": 24291966976,
+                "forward::memory_cpu::pre": 59484168192,
+                "forward::memory_gpu::post": 24291966976,
+                "forward::memory_cpu::post": 59484168192,
+                "forward_warmup::execution": {
+                    "num_iterations": 567,
+                    "total_ms": 5006.345748901367,
+                    "cpu_utilization": 51.3,
+                    "gpu_utilization": 29
+                },
+                "forward::execution": {
+                    "num_iterations": 1135,
+                    "total_ms": 10007.147789001465,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 30
+                },
+                "cleanup::memory_gpu::pre": 24291966976,
+                "cleanup::memory_cpu::pre": 59476750336,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59472855040,
+                "wrap::memory_gpu::pre": 24291966976,
+                "wrap::memory_cpu::pre": 59482882048,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59472855040
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59472855040,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59472855040,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59472855040,
+                "forward::memory_gpu::post": 1892286464,
+                "forward::memory_cpu::post": 59472855040,
+                "forward_warmup::execution": {
+                    "num_iterations": 415,
+                    "total_ms": 5011.237144470215,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 40
+                },
+                "forward::execution": {
+                    "num_iterations": 835,
+                    "total_ms": 10008.896589279175,
+                    "cpu_utilization": 51.7,
+                    "gpu_utilization": 41
+                },
+                "cleanup::memory_gpu::pre": 1892286464,
+                "cleanup::memory_cpu::pre": 59488452608,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59488440320,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59472855040,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59488440320
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59488440320,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59462471680,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59462471680,
+                "forward::memory_gpu::post": 2062155776,
+                "forward::memory_cpu::post": 59466334208,
+                "forward_warmup::execution": {
+                    "num_iterations": 302,
+                    "total_ms": 5003.670692443848,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 56
+                },
+                "forward::execution": {
+                    "num_iterations": 614,
+                    "total_ms": 10002.363920211792,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 55
+                },
+                "cleanup::memory_gpu::pre": 2062155776,
+                "cleanup::memory_cpu::pre": 59492196352,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59492196352,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59488440320,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59492196352
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59492196352,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59469115392,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59469115392,
+                "forward::memory_gpu::post": 1932132352,
+                "forward::memory_cpu::post": 59469115392,
+                "forward_warmup::execution": {
+                    "num_iterations": 450,
+                    "total_ms": 5007.209539413452,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 31
+                },
+                "forward::execution": {
+                    "num_iterations": 907,
+                    "total_ms": 10012.822389602661,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 32
+                },
+                "cleanup::memory_gpu::pre": 1932132352,
+                "cleanup::memory_cpu::pre": 59544199168,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59544915968,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59492196352,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59544915968
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59544915968,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59566645248,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59566645248,
+                "forward::memory_gpu::post": 2039087104,
+                "forward::memory_cpu::post": 59566645248,
+                "forward_warmup::execution": {
+                    "num_iterations": 284,
+                    "total_ms": 5009.858846664429,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 39
+                },
+                "forward::execution": {
+                    "num_iterations": 568,
+                    "total_ms": 10005.614519119263,
+                    "cpu_utilization": 52.3,
+                    "gpu_utilization": 41
+                },
+                "cleanup::memory_gpu::pre": 2039087104,
+                "cleanup::memory_cpu::pre": 59546718208,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59547299840,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59544915968,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59547299840
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59547299840,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59570749440,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59570749440,
+                "forward::memory_gpu::post": 2242510848,
+                "forward::memory_cpu::post": 59570995200,
+                "forward_warmup::execution": {
+                    "num_iterations": 141,
+                    "total_ms": 5000.776052474976,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 42
+                },
+                "forward::execution": {
+                    "num_iterations": 282,
+                    "total_ms": 10001.356363296509,
+                    "cpu_utilization": 52.3,
+                    "gpu_utilization": 48
+                },
+                "cleanup::memory_gpu::pre": 2376728576,
+                "cleanup::memory_cpu::pre": 59569123328,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59569664000,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59547299840,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59569664000
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59569664000,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59546423296,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59546423296,
+                "forward::memory_gpu::post": 1892286464,
+                "forward::memory_cpu::post": 59546423296,
+                "forward_warmup::execution": {
+                    "num_iterations": 350,
+                    "total_ms": 5014.644622802734,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 32
+                },
+                "forward::execution": {
+                    "num_iterations": 700,
+                    "total_ms": 10005.635261535645,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 34
+                },
+                "cleanup::memory_gpu::pre": 1892286464,
+                "cleanup::memory_cpu::pre": 59546722304,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59546722304,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59569664000,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59546722304
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59546722304,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59547578368,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59547578368,
+                "forward::memory_gpu::post": 2313814016,
+                "forward::memory_cpu::post": 59547578368,
+                "forward_warmup::execution": {
+                    "num_iterations": 169,
+                    "total_ms": 5013.458013534546,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 50
+                },
+                "forward::execution": {
+                    "num_iterations": 338,
+                    "total_ms": 10021.129131317139,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 49
+                },
+                "cleanup::memory_gpu::pre": 2313814016,
+                "cleanup::memory_cpu::pre": 59543457792,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59567128576,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59546722304,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59567128576
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59567128576,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59549749248,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59567521792,
+                "forward::memory_gpu::post": 2873753600,
+                "forward::memory_cpu::post": 59567521792,
+                "forward_warmup::execution": {
+                    "num_iterations": 74,
+                    "total_ms": 5004.666090011597,
+                    "cpu_utilization": 52.2,
+                    "gpu_utilization": 49
+                },
+                "forward::execution": {
+                    "num_iterations": 148,
+                    "total_ms": 10018.41115951538,
+                    "cpu_utilization": 52.4,
+                    "gpu_utilization": 50
+                },
+                "cleanup::memory_gpu::pre": 2873753600,
+                "cleanup::memory_cpu::pre": 59554217984,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59567624192,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59567128576,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59567624192
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59567624192,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59567882240,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59567882240,
+                "forward::memory_gpu::post": 2039087104,
+                "forward::memory_cpu::post": 59544633344,
+                "forward_warmup::execution": {
+                    "num_iterations": 253,
+                    "total_ms": 5020.688772201538,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 40
+                },
+                "forward::execution": {
+                    "num_iterations": 505,
+                    "total_ms": 10008.34584236145,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 39
+                },
+                "cleanup::memory_gpu::pre": 2039087104,
+                "cleanup::memory_cpu::pre": 59542843392,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59543101440,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59567624192,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59543101440
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59543101440,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59543101440,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59543334912,
+                "forward::memory_gpu::post": 2735341568,
+                "forward::memory_cpu::post": 59543334912,
+                "forward_warmup::execution": {
+                    "num_iterations": 81,
+                    "total_ms": 5027.507305145264,
+                    "cpu_utilization": 52.2,
+                    "gpu_utilization": 47
+                },
+                "forward::execution": {
+                    "num_iterations": 162,
+                    "total_ms": 10025.571346282959,
+                    "cpu_utilization": 52.3,
+                    "gpu_utilization": 51
+                },
+                "cleanup::memory_gpu::pre": 2869559296,
+                "cleanup::memory_cpu::pre": 59541528576,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59541528576,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59543101440,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59541528576
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59541528576,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59540922368,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59564965888,
+                "forward::memory_gpu::post": 4134141952,
+                "forward::memory_cpu::post": 59564965888,
+                "forward_warmup::execution": {
+                    "num_iterations": 37,
+                    "total_ms": 5121.882677078247,
+                    "cpu_utilization": 52.7,
+                    "gpu_utilization": 61
+                },
+                "forward::execution": {
+                    "num_iterations": 73,
+                    "total_ms": 10002.578973770142,
+                    "cpu_utilization": 52.7,
+                    "gpu_utilization": 57
+                },
+                "cleanup::memory_gpu::pre": 4134141952,
+                "cleanup::memory_cpu::pre": 59541798912,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59563720704,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59541528576,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59563720704
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59563720704,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59539390464,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59539390464,
+                "forward::memory_gpu::post": 2527723520,
+                "forward::memory_cpu::post": 59539390464,
+                "forward_warmup::execution": {
+                    "num_iterations": 153,
+                    "total_ms": 5011.101722717285,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 41
+                },
+                "forward::execution": {
+                    "num_iterations": 305,
+                    "total_ms": 10034.371376037598,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 42
+                },
+                "cleanup::memory_gpu::pre": 2527723520,
+                "cleanup::memory_cpu::pre": 59542614016,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59542614016,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59563720704,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59542614016
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59542614016,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59542872064,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59565064192,
+                "forward::memory_gpu::post": 3851026432,
+                "forward::memory_cpu::post": 59565064192,
+                "forward_warmup::execution": {
+                    "num_iterations": 42,
+                    "total_ms": 5045.50313949585,
+                    "cpu_utilization": 52.3,
+                    "gpu_utilization": 39
+                },
+                "forward::execution": {
+                    "num_iterations": 84,
+                    "total_ms": 10082.253694534302,
+                    "cpu_utilization": 52.4,
+                    "gpu_utilization": 54
+                },
+                "cleanup::memory_gpu::pre": 3851026432,
+                "cleanup::memory_cpu::pre": 59567173632,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59568721920,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59542614016,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59568721920
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59568721920,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59544625152,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59544580096,
+                "forward::memory_gpu::post": 6659112960,
+                "forward::memory_cpu::post": 59544580096,
+                "forward_warmup::execution": {
+                    "num_iterations": 19,
+                    "total_ms": 5102.603435516357,
+                    "cpu_utilization": 52.5,
+                    "gpu_utilization": 43
+                },
+                "forward::execution": {
+                    "num_iterations": 38,
+                    "total_ms": 10257.117748260498,
+                    "cpu_utilization": 52.6,
+                    "gpu_utilization": 69
+                },
+                "cleanup::memory_gpu::pre": 6659112960,
+                "cleanup::memory_cpu::pre": 59551133696,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59551133696,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59568721920,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59551133696
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59551133696,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59574325248,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59574325248,
+                "forward::memory_gpu::post": 3003777024,
+                "forward::memory_cpu::post": 59574325248,
+                "forward_warmup::execution": {
+                    "num_iterations": 73,
+                    "total_ms": 5053.5290241241455,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 39
+                },
+                "forward::execution": {
+                    "num_iterations": 145,
+                    "total_ms": 10049.388647079468,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 40
+                },
+                "cleanup::memory_gpu::pre": 3003777024,
+                "cleanup::memory_cpu::pre": 59556069376,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59574091776,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59551133696,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59574091776
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59574091776,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59552178176,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59552407552,
+                "forward::memory_gpu::post": 6086590464,
+                "forward::memory_cpu::post": 59553804288,
+                "forward_warmup::execution": {
+                    "num_iterations": 21,
+                    "total_ms": 5118.021726608276,
+                    "cpu_utilization": 52.7,
+                    "gpu_utilization": 41
+                },
+                "forward::execution": {
+                    "num_iterations": 42,
+                    "total_ms": 10220.840692520142,
+                    "cpu_utilization": 52.5,
+                    "gpu_utilization": 41
+                },
+                "cleanup::memory_gpu::pre": 6086590464,
+                "cleanup::memory_cpu::pre": 59553705984,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59553705984,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59574091776,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59553705984
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59553705984,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59572543488,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59549822976,
+                "forward::memory_gpu::post": 11700666368,
+                "forward::memory_cpu::post": 59549822976,
+                "forward_warmup::execution": {
+                    "num_iterations": 10,
+                    "total_ms": 5438.496351242065,
+                    "cpu_utilization": 48.8,
+                    "gpu_utilization": 94
+                },
+                "forward::execution": {
+                    "num_iterations": 19,
+                    "total_ms": 10275.27117729187,
+                    "cpu_utilization": 49.0,
+                    "gpu_utilization": 71
+                },
+                "cleanup::memory_gpu::pre": 11700666368,
+                "cleanup::memory_cpu::pre": 59535781888,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59535781888,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59553705984,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59535781888
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59535781888,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59535781888,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59535781888,
+                "forward::memory_gpu::post": 4383703040,
+                "forward::memory_cpu::post": 59535781888,
+                "forward_warmup::execution": {
+                    "num_iterations": 35,
+                    "total_ms": 5039.642095565796,
+                    "cpu_utilization": 52.4,
+                    "gpu_utilization": 33
+                },
+                "forward::execution": {
+                    "num_iterations": 70,
+                    "total_ms": 10020.77317237854,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 38
+                },
+                "cleanup::memory_gpu::pre": 4383703040,
+                "cleanup::memory_cpu::pre": 59545436160,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59558907904,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59535781888,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59558907904
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59558907904,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59559669760,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59536588800,
+                "forward::memory_gpu::post": 10568204288,
+                "forward::memory_cpu::post": 59536588800,
+                "forward_warmup::execution": {
+                    "num_iterations": 11,
+                    "total_ms": 5468.242883682251,
+                    "cpu_utilization": 46.6,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 21,
+                    "total_ms": 10421.819925308228,
+                    "cpu_utilization": 46.7,
+                    "gpu_utilization": 94
+                },
+                "cleanup::memory_gpu::pre": 10568204288,
+                "cleanup::memory_cpu::pre": 59560812544,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59550478336,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59558907904,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59544801280
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59540156416,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59538247680,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59540545536,
+                "forward::memory_gpu::post": 21781676032,
+                "forward::memory_cpu::post": 59533930496,
+                "forward_warmup::execution": {
+                    "num_iterations": 5,
+                    "total_ms": 5896.919965744019,
+                    "cpu_utilization": 35.4,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 9,
+                    "total_ms": 10663.573026657104,
+                    "cpu_utilization": 35.3,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 21781676032,
+                "cleanup::memory_cpu::pre": 59526520832,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59526520832,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59540156416,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59526520832
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59526520832,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59526168576,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59530014720,
+                "forward::memory_gpu::post": 7149846528,
+                "forward::memory_cpu::post": 59548848128,
+                "forward_warmup::execution": {
+                    "num_iterations": 18,
+                    "total_ms": 5232.387065887451,
+                    "cpu_utilization": 48.0,
+                    "gpu_utilization": 45
+                },
+                "forward::execution": {
+                    "num_iterations": 35,
+                    "total_ms": 10194.985151290894,
+                    "cpu_utilization": 47.6,
+                    "gpu_utilization": 47
+                },
+                "cleanup::memory_gpu::pre": 7149846528,
+                "cleanup::memory_cpu::pre": 59556130816,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59556130816,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59526520832,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59556130816
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59556130816,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59533737984,
+                "forward::memory_gpu::pre": 1602879488,
+                "forward::memory_cpu::pre": 59558858752,
+                "forward::memory_gpu::post": 19533529088,
+                "forward::memory_cpu::post": 59530506240,
+                "forward_warmup::execution": {
+                    "num_iterations": 5,
+                    "total_ms": 5522.448539733887,
+                    "cpu_utilization": 35.9,
+                    "gpu_utilization": 100
+                },
+                "forward::execution": {
+                    "num_iterations": 10,
+                    "total_ms": 10893.866062164307,
+                    "cpu_utilization": 34.4,
+                    "gpu_utilization": 100
+                },
+                "cleanup::memory_gpu::pre": 19533529088,
+                "cleanup::memory_cpu::pre": 59528192000,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59534385152,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59556130816,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59534385152
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/tiny",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59534385152,
+                "init::memory_gpu::post": 1602879488,
+                "init::memory_cpu::post": 59529355264,
+                "cleanup::memory_gpu::pre": 18589810688,
+                "cleanup::memory_cpu::pre": 59528654848,
+                "cleanup::memory_gpu::post": 18589810688,
+                "cleanup::memory_cpu::post": 59528691712
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 18589810688,
+                "init::memory_cpu::pre": 59528691712,
+                "init::memory_gpu::post": 18589810688,
+                "init::memory_cpu::post": 59529461760,
+                "forward::memory_gpu::pre": 18589810688,
+                "forward::memory_cpu::pre": 59529461760,
+                "forward::memory_gpu::post": 18589810688,
+                "forward::memory_cpu::post": 59529560064,
+                "forward_warmup::execution": {
+                    "num_iterations": 476,
+                    "total_ms": 5002.718210220337,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 14
+                },
+                "forward::execution": {
+                    "num_iterations": 954,
+                    "total_ms": 10007.080793380737,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 15
+                },
+                "cleanup::memory_gpu::pre": 18589810688,
+                "cleanup::memory_cpu::pre": 59534020608,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59554406400,
+                "wrap::memory_gpu::pre": 18589810688,
+                "wrap::memory_cpu::pre": 59528691712,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59554406400
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59554406400,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59554406400,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59554406400,
+                "forward::memory_gpu::post": 1829371904,
+                "forward::memory_cpu::post": 59554922496,
+                "forward_warmup::execution": {
+                    "num_iterations": 362,
+                    "total_ms": 5004.155158996582,
+                    "cpu_utilization": 51.6,
+                    "gpu_utilization": 22
+                },
+                "forward::execution": {
+                    "num_iterations": 726,
+                    "total_ms": 10013.331651687622,
+                    "cpu_utilization": 51.4,
+                    "gpu_utilization": 22
+                },
+                "cleanup::memory_gpu::pre": 1829371904,
+                "cleanup::memory_cpu::pre": 59531665408,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59531665408,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59554406400,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59531665408
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59531665408,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59531665408,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59531665408,
+                "forward::memory_gpu::post": 2028601344,
+                "forward::memory_cpu::post": 59531665408,
+                "forward_warmup::execution": {
+                    "num_iterations": 290,
+                    "total_ms": 5006.504535675049,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 33
+                },
+                "forward::execution": {
+                    "num_iterations": 580,
+                    "total_ms": 10005.550384521484,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 33
+                },
+                "cleanup::memory_gpu::pre": 2028601344,
+                "cleanup::memory_cpu::pre": 59534393344,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59534393344,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59531665408,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59534393344
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 1,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59534393344,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59558408192,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59537764352,
+                "forward::memory_gpu::post": 1776943104,
+                "forward::memory_cpu::post": 59537764352,
+                "forward_warmup::execution": {
+                    "num_iterations": 382,
+                    "total_ms": 5005.455493927002,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 15
+                },
+                "forward::execution": {
+                    "num_iterations": 753,
+                    "total_ms": 10005.556583404541,
+                    "cpu_utilization": 51.7,
+                    "gpu_utilization": 15
+                },
+                "cleanup::memory_gpu::pre": 1776943104,
+                "cleanup::memory_cpu::pre": 59539324928,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59549130752,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59534393344,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59549130752
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59549130752,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59539652608,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59539652608,
+                "forward::memory_gpu::post": 1917452288,
+                "forward::memory_cpu::post": 59539652608,
+                "forward_warmup::execution": {
+                    "num_iterations": 255,
+                    "total_ms": 5001.541376113892,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 23
+                },
+                "forward::execution": {
+                    "num_iterations": 511,
+                    "total_ms": 10016.228437423706,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 23
+                },
+                "cleanup::memory_gpu::pre": 1917452288,
+                "cleanup::memory_cpu::pre": 59536687104,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59536687104,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59549130752,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59536687104
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59536687104,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59536687104,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59536687104,
+                "forward::memory_gpu::post": 2160721920,
+                "forward::memory_cpu::post": 59536687104,
+                "forward_warmup::execution": {
+                    "num_iterations": 154,
+                    "total_ms": 5008.897066116333,
+                    "cpu_utilization": 52.4,
+                    "gpu_utilization": 28
+                },
+                "forward::execution": {
+                    "num_iterations": 310,
+                    "total_ms": 10027.274370193481,
+                    "cpu_utilization": 52.2,
+                    "gpu_utilization": 28
+                },
+                "cleanup::memory_gpu::pre": 2294939648,
+                "cleanup::memory_cpu::pre": 59540611072,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59540840448,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59536687104,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59540840448
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 2,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59540840448,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59562569728,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59562569728,
+                "forward::memory_gpu::post": 1829371904,
+                "forward::memory_cpu::post": 59562827776,
+                "forward_warmup::execution": {
+                    "num_iterations": 314,
+                    "total_ms": 5013.507127761841,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 19
+                },
+                "forward::execution": {
+                    "num_iterations": 629,
+                    "total_ms": 10014.753818511963,
+                    "cpu_utilization": 51.5,
+                    "gpu_utilization": 19
+                },
+                "cleanup::memory_gpu::pre": 1829371904,
+                "cleanup::memory_cpu::pre": 59542712320,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59550203904,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59540840448,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59550203904
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59550203904,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59544330240,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59544330240,
+                "forward::memory_gpu::post": 2112487424,
+                "forward::memory_cpu::post": 59544330240,
+                "forward_warmup::execution": {
+                    "num_iterations": 170,
+                    "total_ms": 5026.382923126221,
+                    "cpu_utilization": 52.0,
+                    "gpu_utilization": 27
+                },
+                "forward::execution": {
+                    "num_iterations": 340,
+                    "total_ms": 10009.653568267822,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 27
+                },
+                "cleanup::memory_gpu::pre": 2246705152,
+                "cleanup::memory_cpu::pre": 59540402176,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59540402176,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59550203904,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59540402176
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59540402176,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59541164032,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59549421568,
+                "forward::memory_gpu::post": 2580152320,
+                "forward::memory_cpu::post": 59562569728,
+                "forward_warmup::execution": {
+                    "num_iterations": 95,
+                    "total_ms": 5053.59959602356,
+                    "cpu_utilization": 52.4,
+                    "gpu_utilization": 33
+                },
+                "forward::execution": {
+                    "num_iterations": 188,
+                    "total_ms": 10020.296096801758,
+                    "cpu_utilization": 52.5,
+                    "gpu_utilization": 38
+                },
+                "cleanup::memory_gpu::pre": 2580152320,
+                "cleanup::memory_cpu::pre": 59543642112,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59566051328,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59540402176,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59566051328
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 4,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59566051328,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59566755840,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59566755840,
+                "forward::memory_gpu::post": 1917452288,
+                "forward::memory_cpu::post": 59566755840,
+                "forward_warmup::execution": {
+                    "num_iterations": 227,
+                    "total_ms": 5021.116495132446,
+                    "cpu_utilization": 51.8,
+                    "gpu_utilization": 21
+                },
+                "forward::execution": {
+                    "num_iterations": 456,
+                    "total_ms": 10020.23458480835,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 22
+                },
+                "cleanup::memory_gpu::pre": 1917452288,
+                "cleanup::memory_cpu::pre": 59545272320,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59545272320,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59566051328,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59545272320
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59545272320,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59542904832,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59543212032,
+                "forward::memory_gpu::post": 2481586176,
+                "forward::memory_cpu::post": 59543212032,
+                "forward_warmup::execution": {
+                    "num_iterations": 103,
+                    "total_ms": 5015.807628631592,
+                    "cpu_utilization": 52.4,
+                    "gpu_utilization": 33
+                },
+                "forward::execution": {
+                    "num_iterations": 206,
+                    "total_ms": 10049.702167510986,
+                    "cpu_utilization": 52.4,
+                    "gpu_utilization": 33
+                },
+                "cleanup::memory_gpu::pre": 2481586176,
+                "cleanup::memory_cpu::pre": 59542274048,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59542274048,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59545272320,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59542274048
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59542274048,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59542532096,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59542536192,
+                "forward::memory_gpu::post": 3282698240,
+                "forward::memory_cpu::post": 59542536192,
+                "forward_warmup::execution": {
+                    "num_iterations": 47,
+                    "total_ms": 5066.880464553833,
+                    "cpu_utilization": 52.5,
+                    "gpu_utilization": 41
+                },
+                "forward::execution": {
+                    "num_iterations": 94,
+                    "total_ms": 10081.33864402771,
+                    "cpu_utilization": 52.6,
+                    "gpu_utilization": 40
+                },
+                "cleanup::memory_gpu::pre": 3460956160,
+                "cleanup::memory_cpu::pre": 59547705344,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59570667520,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59542274048,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59570667520
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 8,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59570667520,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59570667520,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59570667520,
+                "forward::memory_gpu::post": 2112487424,
+                "forward::memory_cpu::post": 59570667520,
+                "forward_warmup::execution": {
+                    "num_iterations": 147,
+                    "total_ms": 5003.580570220947,
+                    "cpu_utilization": 51.9,
+                    "gpu_utilization": 25
+                },
+                "forward::execution": {
+                    "num_iterations": 295,
+                    "total_ms": 10039.462566375732,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 26
+                },
+                "cleanup::memory_gpu::pre": 2112487424,
+                "cleanup::memory_cpu::pre": 59555999744,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59556044800,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59570667520,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59556044800
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59556044800,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59580264448,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59555983360,
+                "forward::memory_gpu::post": 3091857408,
+                "forward::memory_cpu::post": 59556212736,
+                "forward_warmup::execution": {
+                    "num_iterations": 51,
+                    "total_ms": 5064.820766448975,
+                    "cpu_utilization": 52.5,
+                    "gpu_utilization": 39
+                },
+                "forward::execution": {
+                    "num_iterations": 101,
+                    "total_ms": 10057.230949401855,
+                    "cpu_utilization": 52.9,
+                    "gpu_utilization": 38
+                },
+                "cleanup::memory_gpu::pre": 3091857408,
+                "cleanup::memory_cpu::pre": 59550248960,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59549863936,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59556044800,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59549863936
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59549863936,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59550093312,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59572727808,
+                "forward::memory_gpu::post": 4964614144,
+                "forward::memory_cpu::post": 59550240768,
+                "forward_warmup::execution": {
+                    "num_iterations": 23,
+                    "total_ms": 5098.035573959351,
+                    "cpu_utilization": 53.2,
+                    "gpu_utilization": 38
+                },
+                "forward::execution": {
+                    "num_iterations": 46,
+                    "total_ms": 10078.931093215942,
+                    "cpu_utilization": 53.4,
+                    "gpu_utilization": 46
+                },
+                "cleanup::memory_gpu::pre": 5319032832,
+                "cleanup::memory_cpu::pre": 59586740224,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59574583296,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59549863936,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59574583296
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 16,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59575144448,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59590983680,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59590983680,
+                "forward::memory_gpu::post": 2481586176,
+                "forward::memory_cpu::post": 59591213056,
+                "forward_warmup::execution": {
+                    "num_iterations": 85,
+                    "total_ms": 5021.189451217651,
+                    "cpu_utilization": 52.6,
+                    "gpu_utilization": 33
+                },
+                "forward::execution": {
+                    "num_iterations": 170,
+                    "total_ms": 10010.96487045288,
+                    "cpu_utilization": 52.6,
+                    "gpu_utilization": 28
+                },
+                "cleanup::memory_gpu::pre": 2481586176,
+                "cleanup::memory_cpu::pre": 59597643776,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59574419456,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59575144448,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59574419456
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59574419456,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59574878208,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59597524992,
+                "forward::memory_gpu::post": 4582932480,
+                "forward::memory_cpu::post": 59598000128,
+                "forward_warmup::execution": {
+                    "num_iterations": 25,
+                    "total_ms": 5053.158760070801,
+                    "cpu_utilization": 52.9,
+                    "gpu_utilization": 41
+                },
+                "forward::execution": {
+                    "num_iterations": 49,
+                    "total_ms": 10026.400089263916,
+                    "cpu_utilization": 57.1,
+                    "gpu_utilization": 41
+                },
+                "cleanup::memory_gpu::pre": 4582932480,
+                "cleanup::memory_cpu::pre": 59596828672,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59566493696,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59574419456,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59566493696
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59566493696,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59570135040,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59568705536,
+                "forward::memory_gpu::post": 8324251648,
+                "forward::memory_cpu::post": 59579510784,
+                "forward_warmup::execution": {
+                    "num_iterations": 12,
+                    "total_ms": 5423.646926879883,
+                    "cpu_utilization": 54.8,
+                    "gpu_utilization": 35
+                },
+                "forward::execution": {
+                    "num_iterations": 23,
+                    "total_ms": 10399.644613265991,
+                    "cpu_utilization": 55.1,
+                    "gpu_utilization": 32
+                },
+                "cleanup::memory_gpu::pre": 9033089024,
+                "cleanup::memory_cpu::pre": 59486969856,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59488260096,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59566493696,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59488260096
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 32,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59488260096,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59465334784,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59465334784,
+                "forward::memory_gpu::post": 3091857408,
+                "forward::memory_cpu::post": 59470725120,
+                "forward_warmup::execution": {
+                    "num_iterations": 42,
+                    "total_ms": 5112.979412078857,
+                    "cpu_utilization": 52.5,
+                    "gpu_utilization": 32
+                },
+                "forward::execution": {
+                    "num_iterations": 83,
+                    "total_ms": 10090.57354927063,
+                    "cpu_utilization": 52.5,
+                    "gpu_utilization": 27
+                },
+                "cleanup::memory_gpu::pre": 3091857408,
+                "cleanup::memory_cpu::pre": 59473670144,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59487305728,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59488260096,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59487305728
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59487305728,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59468152832,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59466334208,
+                "forward::memory_gpu::post": 7571374080,
+                "forward::memory_cpu::post": 59468345344,
+                "forward_warmup::execution": {
+                    "num_iterations": 13,
+                    "total_ms": 5367.165088653564,
+                    "cpu_utilization": 53.6,
+                    "gpu_utilization": 39
+                },
+                "forward::execution": {
+                    "num_iterations": 25,
+                    "total_ms": 10273.039102554321,
+                    "cpu_utilization": 52.5,
+                    "gpu_utilization": 78
+                },
+                "cleanup::memory_gpu::pre": 7571374080,
+                "cleanup::memory_cpu::pre": 59460329472,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59460280320,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59487305728,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59460280320
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59460280320,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59467993088,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59457044480,
+                "forward::memory_gpu::post": 15045623808,
+                "forward::memory_cpu::post": 59437600768,
+                "forward_warmup::execution": {
+                    "num_iterations": 5,
+                    "total_ms": 5043.125152587891,
+                    "cpu_utilization": 41.2,
+                    "gpu_utilization": 96
+                },
+                "forward::execution": {
+                    "num_iterations": 10,
+                    "total_ms": 10140.09714126587,
+                    "cpu_utilization": 40.9,
+                    "gpu_utilization": 90
+                },
+                "cleanup::memory_gpu::pre": 15045623808,
+                "cleanup::memory_cpu::pre": 59413458944,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59414044672,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59460280320,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59414044672
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 64,
+            "shape": [
+                1920,
+                1440
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59414044672,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59424067584,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59413118976,
+                "forward::memory_gpu::post": 4582932480,
+                "forward::memory_cpu::post": 59412959232,
+                "forward_warmup::execution": {
+                    "num_iterations": 21,
+                    "total_ms": 5210.696458816528,
+                    "cpu_utilization": 52.1,
+                    "gpu_utilization": 29
+                },
+                "forward::execution": {
+                    "num_iterations": 41,
+                    "total_ms": 10128.963470458984,
+                    "cpu_utilization": 52.6,
+                    "gpu_utilization": 33
+                },
+                "cleanup::memory_gpu::pre": 4582932480,
+                "cleanup::memory_cpu::pre": 59447812096,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59448324096,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59414044672,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59448324096
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                640,
+                480
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59448324096,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59424522240,
+                "forward::memory_gpu::pre": 1592393728,
+                "forward::memory_cpu::pre": 59448520704,
+                "forward::memory_gpu::post": 13548257280,
+                "forward::memory_cpu::post": 59416977408,
+                "forward_warmup::execution": {
+                    "num_iterations": 6,
+                    "total_ms": 5584.286212921143,
+                    "cpu_utilization": 39.8,
+                    "gpu_utilization": 98
+                },
+                "forward::execution": {
+                    "num_iterations": 11,
+                    "total_ms": 10233.174562454224,
+                    "cpu_utilization": 39.6,
+                    "gpu_utilization": 80
+                },
+                "cleanup::memory_gpu::pre": 13548257280,
+                "cleanup::memory_cpu::pre": 59432161280,
+                "cleanup::memory_gpu::post": 1588199424,
+                "cleanup::memory_cpu::post": 59411705856,
+                "wrap::memory_gpu::pre": 1588199424,
+                "wrap::memory_cpu::pre": 59448324096,
+                "wrap::memory_gpu::post": 1588199424,
+                "wrap::memory_cpu::post": 59411705856
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                1280,
+                960
+            ]
+        },
+        {
+            "namespace": "nos::yolox/nano",
+            "profile_data": {
+                "init::memory_gpu::pre": 1588199424,
+                "init::memory_cpu::pre": 59411705856,
+                "init::memory_gpu::post": 1592393728,
+                "init::memory_cpu::post": 59409125376,
+                "cleanup::memory_gpu::pre": 24241635328,
+                "cleanup::memory_cpu::pre": 59407953920,
+                "cleanup::memory_gpu::post": 24241635328,
+                "cleanup::memory_cpu::post": 59407953920
+            },
+            "device_name": "nvidia-geforce-rtx-4090",
+            "device_type": "cuda",
+            "device_index": 0,
+            "batch_size": 128,
+            "shape": [
+                1920,
+                1440
+            ]
+        }
+    ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,10 +34,12 @@ repos:
     - id: debug-statements
     - id: detect-private-key      # check for private keys
     - id: end-of-file-fixer
+      exclude: ^tests/test_data|^.nos/profile
     - id: pretty-format-json
+      exclude: ^tests/test_data|^.nos/profile
     - id: trailing-whitespace
     - id: check-added-large-files
       args: ['--maxkb=100']
-      exclude: ^tests/test_data
+      exclude: ^tests/test_data|^.nos/profile
     - id: requirements-txt-fixer
       files: requirements.*\.txt$

--- a/examples/notebook/nos-benchmarks.ipynb
+++ b/examples/notebook/nos-benchmarks.ipynb
@@ -1,0 +1,196 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "314879f8-1781-46d7-b28d-1a1ae0f19d74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import display, HTML\n",
+    "display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff8dc3a8-3465-4542-89c1-c0b17f0f099f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from nos.common.profiler import NOS_PROFILE_DIR\n",
+    "from nos.common.profiler import Profiler\n",
+    "\n",
+    "# Load all profiles within the cache/profile directory\n",
+    "print(f\"Loading profiles in {NOS_PROFILE_DIR}\")\n",
+    "profiles = list(Path(NOS_PROFILE_DIR).rglob(\"*.json\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffde5260-d5de-47d7-a7b4-34f6f78d1717",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import pandas as pd\n",
+    "\n",
+    "pd.set_option(\"mode.chained_assignment\", None)\n",
+    "pd.set_option('display.max_colwidth', 0)\n",
+    "pd.set_option('display.max_rows', 500)\n",
+    "pd.set_option('display.max_columns', None)\n",
+    "\n",
+    "\n",
+    "# Load all profiles into a dataframe\n",
+    "def load_profile(filename):\n",
+    "    try:\n",
+    "        print(f\"Loading {filename}\")\n",
+    "        return Profiler.load_records(filename)\n",
+    "    except:\n",
+    "        print(f\"Failed to load {filename}\")\n",
+    "df = pd.concat([load_profile(p) for p in profiles])\n",
+    "print(f\"Loaded profiles: {len(df)}\")\n",
+    "\n",
+    "# Rename columns names with profile_data.* \n",
+    "df = df.rename(columns={col: col.replace(\"profile_data.\", \"\") for col in df.columns})\n",
+    "\n",
+    "# Convert memory columns to GB\n",
+    "for col in df.columns:\n",
+    "    if \"::memory_\" in col:\n",
+    "        df[col] /= 1024 **3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7ff250c-68ac-4f99-8f16-0eec1bb49cc2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "479841bd-d100-417e-bff1-d80eeaf978ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = df.assign(\n",
+    "    latency_ms=lambda x: x[\"forward::execution.total_ms\"] / x[\"forward::execution.num_iterations\"],\n",
+    "    throughput=lambda x: x[\"forward::execution.num_iterations\"] * x[\"batch_size\"] / (x[\"forward::execution.total_ms\"] / 1e3),\n",
+    "    gpu_utilization=lambda x: x[\"forward::execution.gpu_utilization\"],\n",
+    "    cpu_utilization=lambda x: x[\"forward::execution.cpu_utilization\"],\n",
+    "    cuda_torch_mem_usage_gb=lambda x: x[\"init::memory_gpu::post\"],\n",
+    "    cuda_mem_usage_gb=lambda x: x[\"forward::memory_gpu::post\"] - x[\"init::memory_gpu::pre\"],\n",
+    "    model_id = lambda x: x[\"namespace\"].astype(str) + \" [b=\" + x[\"batch_size\"].astype(str) + \", d=\" + x[\"device_index\"].astype(str) + \", \" + x[\"device_name\"].astype(str) + \"]\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff667baf-27ee-4350-9b00-5a9a8ce86104",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6cdcafda-7201-45cd-8ca9-dba644b86879",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "from pathlib import Path\n",
+    "from IPython.display import FileLink, FileLinks\n",
+    "\n",
+    "date_str = datetime.utcnow().strftime(\"%Y%m%d\")\n",
+    "path = Path.cwd() / f\"profiles/nos_profile_aggregate_{date_str}.csv\"\n",
+    "path.parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "df.to_csv(str(path), index=False)\n",
+    "FileLink(path.relative_to(Path.cwd()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3d0364c-0c22-4967-a856-3fb02eb152f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install pygsheets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d0011af-5f44-4119-afa8-5ae293dfdb8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pygsheets\n",
+    "\n",
+    "def write_to_gsheet(client_secret, spreadsheet_id, sheet_name, data_df):\n",
+    "    \"\"\"\n",
+    "    this function takes data_df and writes it under spreadsheet_id\n",
+    "    and sheet_name using your credentials under service_file_path\n",
+    "    \"\"\"\n",
+    "    gc = pygsheets.authorize(client_secret=client_secret)\n",
+    "    sh = gc.open_by_key(spreadsheet_id)\n",
+    "    try:\n",
+    "        sh.add_worksheet(sheet_name)\n",
+    "    except:\n",
+    "        pass\n",
+    "    wks_write = sh.worksheet_by_title(sheet_name)\n",
+    "    wks_write.clear('A1',None,'*')\n",
+    "    wks_write.set_dataframe(data_df, (1,1), encoding='utf-8', fit=True)\n",
+    "    wks_write.frozen_rows = 1\n",
+    "\n",
+    "# Upload to nos-benchmarks\n",
+    "# Note: Download the client creds JSON from here: \n",
+    "#    https://console.cloud.google.com/apis/credentials/oauthclient/851725070723-anse9hqc5clo0qm3lgtvshs5nnku8lhh.apps.googleusercontent.com?project=nos-benchmarks\n",
+    "WORKSHEET_ID = \"14Ee2PR8c-1yQg6MCcElYymW67sjdSBlG-1AGW3Yuf2w\"\n",
+    "date_str = datetime.utcnow().strftime(\"%Y%m%d\")\n",
+    "write_to_gsheet(\"creds.json\", WORKSHEET_ID, f\"nos-benchmarks-{date_str}\", df)\n",
+    "write_to_gsheet(\"creds.json\", WORKSHEET_ID, f\"nos-benchmarks\", df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3ed9ed9-d49c-4d74-85b7-2a549397641e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/nos/cli/benchmark.py
+++ b/nos/cli/benchmark.py
@@ -1,0 +1,303 @@
+import gc
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from itertools import product
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Tuple, Union
+
+import numpy as np
+import pandas as pd
+import torch
+import typer
+from PIL import Image
+from rich.console import Console
+
+from nos import hub
+from nos.common import TaskType, tqdm
+from nos.common.profiler import Profiler
+from nos.common.system import get_system_info, has_gpu, is_inside_docker
+from nos.constants import NOS_CACHE_DIR
+from nos.logging import logger
+from nos.test.utils import NOS_TEST_IMAGE
+from nos.version import __version__
+
+
+@dataclass(frozen=True)
+class ProfileResult:
+    profile: pd.DataFrame
+    """Profiled results as a dataframe."""
+    acc_info: Dict[str, Any] = None
+    """Accelerator (GPU) info."""
+
+    def __post_init__(self):
+        assert isinstance(self.profile, pd.DataFrame), "Profile must be a DataFrame."
+        assert self.profile.index.name == "key", "Profile must have a 'key' index."
+        assert "device_id" in self.profile.columns, "Profile must have a device_id."
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to a dictionary."""
+        return {
+            "profile": self.profile.to_dict(),
+            "sys_info": get_system_info(docker=False, gpu=True),
+        }
+
+    def save(self, filename: Union[str, Path]) -> None:
+        """Save profiled results to JSON."""
+        import json
+
+        with open(str(filename), "w") as f:
+            json.dump(self.to_dict(), f, indent=4)
+
+
+benchmark_cli = typer.Typer(name="benchmark", help="NOS Benchmark CLI.", no_args_is_help=True)
+console = Console()
+
+
+@benchmark_cli.command("list", help="List model benchmark results.")
+def _benchmark_list() -> None:
+    pass
+
+
+@benchmark_cli.command("run", help="Run model benchmarks, and profile if needed.")
+def _benchmark_run() -> None:
+    pass
+
+
+@dataclass(frozen=True)
+class BenchmarkModel:
+    task: TaskType
+    """Task type."""
+    name: str
+    """Model name."""
+    batch_size: int
+    """Batch size."""
+    shape: Tuple[int]
+    """Input shape."""
+    image: Image.Image
+    """Input image."""
+    get_inputs: Callable
+    """Callable to get inputs."""
+
+    def __repr__(self) -> str:
+        return f"BenchmarkModel (task={self.task}, name={self.name}, bsize={self.batch_size}, shape={self.shape}, image={self.image.size})"
+
+
+@dataclass
+class BenchmarkProfiler:
+    """Benchmark profiler.
+
+    Usage:
+        >>> from nos.cli.benchmark import BenchmarkProfiler
+        >>> profiler = BenchmarkProfiler(models=[...])
+    """
+
+    models: List[BenchmarkModel] = field(default_factory=list)
+    """Models to benchmark."""
+    prof: Profiler = None
+    """Profiler used for benchmarking."""
+    device_id: int = -1
+    """Device ID."""
+    device_name: str = None
+    """Device name."""
+    device: torch.device = None
+    """Torch Device to run benchmark."""
+
+    def __repr__(self) -> str:
+        repr_str = (
+            f"BenchmarkProfiler (models={len(self.models)}, device_name={self.device_name}, device={self.device})"
+        )
+        for model in self.models:
+            repr_str += f"\n\t{model}"
+        return repr_str
+
+    def __post_init__(self) -> None:
+        """Setup the device and profiler."""
+
+        # Get system info
+        sysinfo = get_system_info(docker=True, gpu=True)
+
+        # GPU / CPU acceleration
+        if torch.cuda.is_available():
+            assert has_gpu(), "CUDA is not available."
+            assert sysinfo["gpu"] is not None, "No CUDA devices found."
+
+            # Print GPU devices before running benchmarks
+            gpu_devices = sysinfo["gpu"]["devices"]
+            gpu_devices_df = pd.json_normalize(gpu_devices)
+            unique_gpu_devices = gpu_devices_df["device_name"].unique()
+            console.print(f"Found GPU devices: {len(gpu_devices_df)}, unique: {len(unique_gpu_devices)}")
+            if len(unique_gpu_devices) > 1:
+                console.print(f"Multiple devices detected, selecting {unique_gpu_devices[0]}.")
+            console.print(gpu_devices_df.to_markdown())
+
+            # Select the appropriate device, and retrieve its name
+            self.device_name = gpu_devices_df["device_name"].iloc[self.device_id]
+            self.device_name = self.device_name.replace(" ", "-").lower()
+            self.device = torch.device(f"cuda:{self.device_id}")
+            assert self.device.index == self.device_id, "Device index mismatch."
+            assert self.device.type == "cuda", "Device type mismatch."
+        else:
+            # CPU device
+            self.device_id, self.device_name = -1, "cpu"
+            self.device = torch.device("cpu")
+
+    def add(self, model: BenchmarkModel) -> None:
+        """Add a model to the profiler."""
+        self.models.append(model)
+
+    def _benchmark(self, bmodel: BenchmarkModel) -> None:
+        """Benchmark / profile a specific model."""
+
+        # Add a new record to profile
+        record = self.prof.add(
+            f"nos::{bmodel.name}",
+            device_name=self.device_name,
+            device_type=self.device.type,
+            device_index=self.device.index,
+            batch_size=bmodel.batch_size,
+            shape=bmodel.shape,
+        )
+        with record.profile_memory("wrap"):
+            try:
+                # Initialize (profile memory)
+                with record.profile_memory("init"):
+                    spec = hub.load_spec(bmodel.name, bmodel.task)
+                    model = hub.load(spec.name, spec.task)
+                    predict = getattr(model, spec.signature.method_name)
+
+                # Inference (profile memory)
+                batched_inputs = bmodel.get_inputs(bmodel.image, bmodel.shape, bmodel.batch_size)
+                with record.profile_memory("forward"):
+                    predict(**batched_inputs)
+
+                # Inference Warmup
+                with record.profile_execution("forward_warmup", duration=5) as p:
+                    [predict(**batched_inputs) for _ in p.iterator]
+
+                # Inference (profile execution)
+                with record.profile_execution("forward", duration=10) as p:
+                    [predict(**batched_inputs) for _ in p.iterator]
+
+            except Exception as e:
+                logger.error(f"Failed to profile, e={e}")
+                raise e
+
+            finally:
+                # Destroy
+                with record.profile_memory("cleanup"):
+                    try:
+                        del model.model
+                    except Exception:
+                        pass
+                    model.model = None
+                    gc.collect()
+                    torch.cuda.empty_cache()
+
+    def run(self) -> None:
+        """Run all benchmarks."""
+        failed = {}
+        st_t = time.time()
+
+        console.print("[bold green] Running benchmarks ...")
+        console.print(f"[bold white] {self} [/bold white]")
+        with Profiler() as self.prof, torch.inference_mode():
+            pbar = tqdm(self.models)
+            for bmodel in pbar:
+                # Skip subsequent benchmarks with same name if previous runs failed
+                # Note: This is to avoid running benchmarks that previously failed
+                # due to OOM with smaller batch sizes.
+                if bmodel.name in failed and bmodel.batch_size >= failed[bmodel.name].batch_size:
+                    logger.debug(f"Skipping benchmark, since previous run failed: {bmodel}")
+                    continue
+                pbar.set_description(
+                    f"Profiling [name={bmodel.name}, bsize={bmodel.batch_size}, shape={bmodel.shape}, device={self.device_name}]"
+                )
+                try:
+                    self._benchmark(bmodel)
+                except Exception:
+                    logger.error(f"Profiling failed: {bmodel}.")
+                    failed[bmodel.name] = bmodel
+                    continue
+        console.print(f"[bold green] Benchmarks completed (elapsed={time.time() - st_t:.1f}s) [/bold green]")
+
+    def save(self) -> None:
+        """Save profiled results to JSON."""
+        NOS_PROFILE_DIR = NOS_CACHE_DIR / "profile"
+        NOS_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
+
+        version_str = __version__.replace(".", "-")
+        date_str = datetime.utcnow().strftime("%Y%m%d")
+        profile_path = Path(NOS_PROFILE_DIR) / f"nos-profile--{version_str}--{date_str}--{self.device_name}.json"
+        console.print(
+            f"[bold green] Writing profile results to {profile_path} (records={len(self.prof.records)})[/bold green]"
+        )
+        self.prof.save(profile_path)
+
+
+@benchmark_cli.command("profile", help="Profile all models.")
+def _benchmark_profile(
+    device_id: int = typer.Option(0, "--device-id", "-d", help="Device ID to use."),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose profiling."),
+) -> None:
+    """Profile all models.
+
+    Usage:
+        $ CUDA_DEVICE_ORDER=PCI_BUS_ID CUDA_VISIBLE_DEVICES=0 nos benchmark profile --verbose
+    """
+
+    if not is_inside_docker():
+        logger.warning("nos benchmarks should be ideally run within docker, continuing ...")
+
+    # TODO (spillai): Pytorch cuda.devices are reported in the descending order of memory,
+    # so we need to force them to match the `nvidia-smi` order. Setting CUDA_DEVICE_ORDER=PCI_BUS_ID
+    # allows us to keep the order consistent with `nvidia-smi`.
+    assert os.getenv("CUDA_DEVICE_ORDER", "") == "PCI_BUS_ID", "CUDA_DEVICE_ORDER must be PCI_BUS_ID."
+
+    # Disables SettingWithCopyWarning
+    pd.set_option("mode.chained_assignment", None)
+
+    # Load test image
+    pil_im = Image.open(NOS_TEST_IMAGE)
+
+    # Create benchmark experiments from varied tasks, batch sizes and input shapes
+    BATCH_SIZES = [2**b for b in range(11)]
+
+    benchmark = BenchmarkProfiler(device_id=device_id)
+    for spec in hub.list():
+        if spec.task == TaskType.IMAGE_EMBEDDING:
+            SHAPES = [(224, 224), (640, 480)]
+            for (batch_size, shape) in product(BATCH_SIZES, SHAPES):
+                benchmark.add(
+                    BenchmarkModel(
+                        task=spec.task,
+                        name=spec.name,
+                        batch_size=batch_size,
+                        shape=shape,
+                        image=pil_im,
+                        get_inputs=lambda im, shape, batch_size: {
+                            "images": [np.asarray(im.resize(shape)) for _ in range(batch_size)]
+                        },
+                    )
+                )
+        elif spec.task == TaskType.OBJECT_DETECTION_2D:
+            SHAPES = [(640, 480), (1280, 960), (1920, 1440)]
+            for (batch_size, shape) in product(BATCH_SIZES, SHAPES):
+                benchmark.add(
+                    BenchmarkModel(
+                        task=spec.task,
+                        name=spec.name,
+                        batch_size=batch_size,
+                        shape=shape,
+                        image=pil_im,
+                        get_inputs=lambda im, shape, batch_size: {
+                            "images": [np.asarray(im.resize(shape)) for _ in range(batch_size)]
+                        },
+                    )
+                )
+
+    # Run benchmarks
+    benchmark.models = benchmark.models
+    benchmark.run()
+    benchmark.save()

--- a/nos/cli/cli.py
+++ b/nos/cli/cli.py
@@ -1,5 +1,6 @@
 import typer
 
+from nos.cli.benchmark import benchmark_cli
 from nos.cli.docker import docker_cli
 from nos.cli.hub import hub_cli
 from nos.cli.predict import predict_cli
@@ -8,6 +9,7 @@ from nos.cli.system import system_cli
 
 app_cli = typer.Typer(no_args_is_help=True)
 app_cli.add_typer(hub_cli)
+app_cli.add_typer(benchmark_cli)
 app_cli.add_typer(system_cli)
 app_cli.add_typer(docker_cli)
 app_cli.add_typer(predict_cli)

--- a/nos/common/profiler.py
+++ b/nos/common/profiler.py
@@ -1,16 +1,24 @@
 import contextlib
 import datetime
+import gc
+import json
+import os
+import time
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, List, Union
 
 import pandas as pd
+import psutil
 import torch
 from torch.profiler import ProfilerActivity, profile  # noqa
 from torch.profiler import record_function as _record_function  # noqa
 
-from nos.common.system import has_gpu
+from nos.common import tqdm
+from nos.common.system import get_system_info, has_gpu
 from nos.constants import NOS_CACHE_DIR
 from nos.logging import logger
+from nos.version import __version__
 
 
 NOS_PROFILE_DIR = NOS_CACHE_DIR / "profile"
@@ -18,24 +26,231 @@ NOS_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
 DEFAULT_PROFILER_SCHEDULE = torch.profiler.schedule(wait=10, warmup=10, active=80, repeat=0)
 
 
+@dataclass
+class ExecutionStats:
+    """Execution statistics."""
+
+    num_iterations: int
+    """Number of iterations."""
+    total_ms: float
+    """Total time in milliseconds."""
+    cpu_utilization: float
+    """CPU utilization."""
+    gpu_utilization: Union[None, float]
+    """GPU utilization."""
+
+    @property
+    def fps(self):
+        return self.num_iterations / (self.total_ms * 1e3)
+
+
+class profile_execution:
+    """Context manager for profiling execution."""
+
+    def __init__(self, name: str, iterations: int = None, duration: float = None):
+        if iterations is None and duration is None:
+            raise ValueError("Either `iterations` or `duration` must be specified.")
+        self.iterations = iterations
+        self.duration = duration
+        self.name = f"{name}::execution"
+        self.iterator = None
+        self.execution_stats = None
+
+    def __repr__(self) -> str:
+        return (
+            f"""{self.__class__.__name__} """
+            f"""(name={self.name}, iterations={self.iterations}, duration={self.duration}, """
+            f"""stats={self.execution_stats})"""
+        )
+
+    def __enter__(self) -> "profile_execution":
+        """Start profiling execution."""
+        # Note (spillai): The first call to `cpu_percent` with `interval=None` starts
+        # capturing the CPU utilization. The second call in `__exit__` returns
+        # the average CPU utilization over the duration of the context manager.
+        _ = psutil.cpu_percent(interval=None)
+        self.iterator = (
+            tqdm(duration=self.duration, desc=self.name)
+            if self.duration
+            else tqdm(total=self.iterations, desc=self.name)
+        )
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
+        """Stop profiling."""
+        end_t = time.time()
+        cpu_util = psutil.cpu_percent(interval=None)
+        try:
+            # TOFIX (spillai): This will be fixed with torch 2.1
+            gpu_util = torch.cuda.utilization(int(os.getenv("CUDA_VISIBLE_DEVICES", None)))
+        except Exception:
+            gpu_util = None
+        self.execution_stats = ExecutionStats(
+            self.iterator.n, (end_t - self.iterator.start_t) * 1e3, cpu_util, gpu_util
+        )
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self.iterator)
+
+
+class profile_memory:
+    """Context manager for profiling memory usage (GPU/CPU)."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.memory_stats = {}
+
+    def __repr__(self) -> str:
+        return f"""{self.__class__.__name__} (name={self.name}, stats={self.memory_stats})"""
+
+    def __enter__(self) -> "profile_memory":
+        """Start profiling GPU memory usage."""
+        try:
+            free, total = torch.cuda.mem_get_info()
+            self.memory_stats[f"{self.name}::memory_gpu::pre"] = total - free
+        except Exception:
+            self.memory_stats[f"{self.name}::memory_gpu::pre"] = None
+        finally:
+            free, total = psutil.virtual_memory().available, psutil.virtual_memory().total
+            self.memory_stats[f"{self.name}::memory_cpu::pre"] = total - free
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
+        """Stop profiling GPU memory usage."""
+        try:
+            free, total = torch.cuda.mem_get_info()
+            self.memory_stats[f"{self.name}::memory_gpu::post"] = total - free
+        except Exception:
+            self.memory_stats[f"{self.name}::memory_gpu::post"] = None
+        finally:
+            free, total = psutil.virtual_memory().available, psutil.virtual_memory().total
+            self.memory_stats[f"{self.name}::memory_cpu::post"] = total - free
+        return
+
+    def memory_usage(self):
+        return self.memory_stats
+
+
+class profiler_record:
+    """Profile record for capturing profiling data (execution profile, memory profile, etc.)."""
+
+    def __init__(self, namespace: str, **kwargs):
+        self.namespace = namespace
+        self.kwargs = kwargs
+        self.profile_data = {}
+
+    @contextlib.contextmanager
+    def profile_execution(self, name: str = None, iterations: int = None, duration: float = None) -> profile_execution:
+        """Context manager for profiling execution time."""
+        with profile_execution(f"{name}", iterations=iterations, duration=duration) as prof:
+            yield prof
+        self.profile_data[prof.name] = prof.execution_stats.__dict__
+        print(prof)
+
+    @contextlib.contextmanager
+    def profile_memory(self, name: str = None) -> profile_memory:
+        """Context manager for profiling memory usage."""
+        with profile_memory(f"{name}") as prof:
+            yield prof
+        # TODO (spillai): This is to avoid nested namespaces in the profile data dict.
+        self.profile_data.update(prof.memory_usage())
+        print(prof)
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return a dictionary representation of the profiler record."""
+        return {
+            "namespace": self.namespace,
+            "profile_data": self.profile_data,
+            **self.kwargs,
+        }
+
+
+@dataclass
+class Profiler:
+    """NOS profiler as a context manager."""
+
+    records: List[profiler_record] = field(default_factory=list)
+    """List of profiler records."""
+
+    def __enter__(self) -> "Profiler":
+        """Start profiling benchmarks, clearing all torch.cuda cache/stats ."""
+        try:
+            torch.cuda.empty_cache()
+            torch.cuda.reset_peak_memory_stats()
+            torch.cuda.reset_accumulated_memory_stats()
+        except Exception:
+            pass
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
+        """Stop profiling benchmarks."""
+        try:
+            torch.cuda.empty_cache()
+            torch.cuda.reset_peak_memory_stats()
+            torch.cuda.reset_accumulated_memory_stats()
+        except Exception:
+            pass
+        gc.collect()
+        return
+
+    def add(self, name: str, **kwargs) -> profiler_record:
+        """Add a profiler record."""
+        if len(self.records) > 0 and self.records[0].kwargs.keys() != kwargs.keys():
+            raise ValueError("Adding a new record with different kwargs is not supported.")
+        self.records.append(profiler_record(name, **kwargs))
+        return self.records[-1]
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return a dictionary representation of the profiler."""
+        return {
+            "date": datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+            "nos_version": __version__,
+            "sysinfo": get_system_info(docker=True, gpu=True),
+            "records": [r.as_dict() for r in self.records],
+        }
+
+    def __repr__(self) -> str:
+        """Return a string representation of the profiler."""
+        return json.dumps(self.as_dict(), indent=4)
+
+    def save(self, filename: Union[Path, str]) -> None:
+        """Save profiled results to a file."""
+        with open(str(filename), "w") as f:
+            json.dump(self.as_dict(), f, indent=4)
+
+    @classmethod
+    def load(cls, filename: Union[Path, str]) -> Dict[str, Any]:
+        """Load profiled results."""
+        with open(str(filename), "r") as f:
+            return json.load(f)
+
+    @classmethod
+    def load_metadata(cls, filename: Union[Path, str]) -> pd.DataFrame:
+        """Load profiled metadata."""
+        data = cls.load(filename)
+        _ = data.pop("records")
+        return data
+
+    @classmethod
+    def load_records(cls, filename: Union[Path, str]) -> pd.DataFrame:
+        """Load profiled records as a dataframe."""
+        data = cls.load(filename)
+        records = data.pop("records")
+        return pd.json_normalize(records)
+
+
 @contextlib.contextmanager
-def record_function(name: str, args: Optional[str] = None):
-    """Default NOS record_function."""
-
-    with _record_function(name, args) as rf:
-        rf._gpu_memory_usage = {}
-        rf._gpu_memory_usage[f"{name}::_before"] = torch.cuda.mem_get_info()
-        yield rf
-        rf._gpu_memory_usage[f"{name}::_after"] = torch.cuda.mem_get_info()
-
-
-@contextlib.contextmanager
-def profiler(
+def _profiler(
     schedule: torch.profiler.schedule = None, profile_memory: bool = False, export_chrome_trace: bool = False
 ):
     """Default NOS profiler as a context manager."""
     activities = [ProfilerActivity.CPU, ProfilerActivity.CUDA] if has_gpu() else [ProfilerActivity.CPU]
     with profile(activities=activities, schedule=schedule, profile_memory=profile_memory) as prof:
+        prof._sys_info = get_system_info()
+        prof._mem_prof = {}
         yield prof
 
     if export_chrome_trace:


### PR DESCRIPTION
Full scaffolding for memory and GPU execution profiling with benchmark CLI tool and notebook report.

```sh
Usage:
  $ CUDA_DEVICE_ORDER=PCI_BUS_ID CUDA_VISIBLE_DEVICES=0 nos benchmark profile --verbose
```



<!-- Thank you for your contribution! Please review https://github.com/autonomi-ai/nos/blob/main/docs/CONTRIBUTING.md before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Summary

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

Closes #214 

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
