### PR TITLE
Improved `nos.init(logging_level=...)` with verbose debug logs

### DIFF
--- a/tests/integrations/test_pixeltable.py
+++ b/tests/integrations/test_pixeltable.py
@@ -175,6 +175,7 @@ def test_pixeltable_integration():
 
     # Run inference (see acceptance criteria from timing table above)
     timing_records = []
+    t[noop(t.frame)].show(1)  # noop (warmup)
     with timer(f"noop_{W}x{H}", n=nframes) as info:
         t.add_column(pt.Column("noop_ids", computed_with=noop(t.frame)))
     logger.info(info)

--- a/tests/server/test_server_utils.py
+++ b/tests/server/test_server_utils.py
@@ -1,0 +1,69 @@
+import logging
+
+import psutil
+import pytest
+
+import nos
+from nos.common.system import has_docker
+from nos.server import InferenceServiceRuntime
+
+
+# Skip this entire test if docker is not installed
+num_cpus = psutil.cpu_count(logical=False)
+pytestmark = pytest.mark.skipif(not has_docker() or num_cpus < 4, reason="docker is not installed")
+
+
+def test_nos_init():
+    """Test the NOS server daemon initialization.
+
+    See tests/client/test_client_integration.py for the end-to-end integration with client.
+    """
+
+    # Initialize the server
+    container_1 = nos.init(logging_level=logging.DEBUG)
+    assert container_1 is not None
+    container_2 = nos.init(logging_level="DEBUG")
+    assert container_2 is not None
+    assert container_1.id == container_2.id
+
+    containers = InferenceServiceRuntime.list()
+    assert len(containers) == 1
+
+    # Shutdown the server
+    nos.shutdown()
+
+    containers = InferenceServiceRuntime.list()
+    assert len(containers) == 0
+
+    # Shutdown the server again (should not raise an error)
+    nos.shutdown()
+
+
+def test_nos_init_variants():
+    """Test the NOS server daemon initialization variants."""
+    import logging
+
+    with pytest.raises(ValueError):
+        nos.init(runtime="invalid")
+
+    for utilization in [-1, 0.0, 1.1]:
+        with pytest.raises(ValueError):
+            nos.init(utilization=utilization)
+
+    with pytest.raises(ValueError):
+        nos.init(logging_level="invalid")
+
+    with pytest.raises(ValueError):
+        nos.init(logging_level=0)
+
+    with pytest.raises(ValueError):
+        nos.init(tag=0)
+
+    with pytest.raises(NotImplementedError):
+        nos.init(tag="latest")
+
+    with pytest.raises(ValueError):
+        nos.init(logging_level="invalid")
+
+    nos.init(runtime="cpu", utilization=0.5, logging_level=logging.INFO)
+    nos.shutdown()


### PR DESCRIPTION
 - debug logs per-request time-elapsed, input types, model spec etc

<!-- Thank you for your contribution! Please review https://github.com/autonomi-ai/nos/blob/main/docs/CONTRIBUTING.md before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Summary

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
