### PR TITLE
More granular/useful client exception types

### DIFF
--- a/nos/client/exceptions.py
+++ b/nos/client/exceptions.py
@@ -14,17 +14,20 @@ class NosClientException(Exception):
     def __str__(self) -> str:
         return f"{self.message}"
 
+
 class NosServerReadyException(NosClientException):
     """Exception raised when the server is not ready."""
 
     def __str__(self) -> str:
         return f"Server not ready. {self.message}"
 
+
 class NosInputValidationException(NosClientException):
     """Exception raised when input validation fails."""
 
     def __str__(self) -> str:
         return f"Input validation failed. {self.message}"
+
 
 class NosInferenceException(NosClientException):
     """Exception raised when inference fails."""

--- a/nos/client/grpc.py
+++ b/nos/client/grpc.py
@@ -10,8 +10,11 @@ import numpy as np
 from google.protobuf import empty_pb2
 from PIL import Image
 
-from nos.client.exceptions import NosClientException, NosServerReadyException, NosInputValidationException, NosInferenceException
-
+from nos.client.exceptions import (
+    NosClientException,
+    NosInferenceException,
+    NosServerReadyException,
+)
 from nos.common import FunctionSignature, ModelSpec, TaskType, TensorSpec, dumps, loads
 from nos.common.shm import NOS_SHM_ENABLED, SharedMemoryTransportManager
 from nos.constants import DEFAULT_GRPC_PORT, NOS_PROFILING_ENABLED


### PR DESCRIPTION
#232 Right now every failure gets raised as a `NosClientException`. Going forward we need to start splitting these out into specific error categories, including:
1) Failing to connect to the server/server not ready
2) Failing to validate the input (malformed request)
3) Failed inference (broken model, OOM, etc.)

This is just a small subset, all of which derive from `NosClientException`. Should all be covered in Nos docs.

## Summary

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
