### PR TITLE
Include a set of recommended resolutions with model info for image mo…

### DIFF
--- a/nos/client/grpc.py
+++ b/nos/client/grpc.py
@@ -191,7 +191,12 @@ class InferenceClient:
         """
         try:
             response: nos_service_pb2.ModelListResponse = self.stub.ListModels(empty_pb2.Empty())
-            return [ModelSpec(name=minfo.name, task=TaskType(minfo.task)) for minfo in response.models]
+            return [
+                ModelSpec(
+                    name=minfo.name, task=TaskType(minfo.task), recommended_resolutions=minfo.recommended_resolutions
+                )
+                for minfo in response.models
+            ]
         except grpc.RpcError as e:
             raise NosClientException(f"Failed to list models (details={e.details()})", e)
 

--- a/nos/common/spec.py
+++ b/nos/common/spec.py
@@ -189,6 +189,8 @@ class ModelSpec:
     """Task type (e.g. image_embedding, image_generation, object_detection_2d, etc)."""
     signature: FunctionSignature = None
     """Model function signature."""
+    recommended_resolutions: List[Tuple[int, int]] = None
+    """recommended image resolutions for image models."""
 
     @staticmethod
     def get_id(model_name: str, task: TaskType = None) -> str:

--- a/nos/hub/__init__.py
+++ b/nos/hub/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 from nos.common import FunctionSignature, ModelSpec, TaskType  # noqa: F401
 from nos.hub.config import HuggingFaceHubConfig, MMLabConfig, NosHubConfig, TorchHubConfig  # noqa: F401
@@ -91,6 +91,7 @@ class Hub:
                 init_kwargs=kwargs.pop("init_kwargs", {}),
                 method_name=kwargs.pop("method_name", None),
             ),
+            recommended_resolutions=kwargs.pop("recommended_resolutions", None),
         )
         model_id = ModelSpec.get_id(spec.name, spec.task)
         if model_id not in cls.get()._registry:

--- a/nos/models/clip.py
+++ b/nos/models/clip.py
@@ -236,4 +236,5 @@ for model_name in CLIP.configs:
         method_name="encode_image",
         inputs={"images": Batch[ImageT[Image.Image]]},
         outputs={"embedding": Batch[TensorT[np.ndarray, EmbeddingSpec(shape=(cfg.D,), dtype="float32")]]},
+        recommended_resolutions=[(224, 224)],
     )


### PR DESCRIPTION
#249 Easiest to include this with the existing model info and gradually add image sizes based on profiling results.

## Summary

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
