### PR TITLE
Fix `NOS_MEMRAY_ENABLED` flags with defaults

### DIFF
--- a/nos/managers/model.py
+++ b/nos/managers/model.py
@@ -16,12 +16,13 @@ from nos.common import ModelSpec
 from nos.logging import logger
 
 
-NOS_MEMRAY_ENABLED = os.getenv("NOS_MEMRAY_ENABLED")
+NOS_MEMRAY_ENABLED = bool(int(os.getenv("NOS_MEMRAY_ENABLED", "0")))
 NOS_RAY_LOGS_DIR = os.getenv("NOS_RAY_LOGS_DIR", "/tmp/ray/session_latest/logs")
 
 if NOS_MEMRAY_ENABLED:
-    NOS_RAY_LOGS_DIR.mkdir(parents=True, exist_ok=True)
     import memray
+
+    Path(NOS_RAY_LOGS_DIR).mkdir(parents=True, exist_ok=True)
 
 
 class ModelResultQueue(Queue):


### PR DESCRIPTION
## Summary

This resolves the `nos-inference-service-gpu` failure on startup

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
