### PR TITLE
Support manual weights path for civit models

### DIFF
--- a/tests/models/test_dreambooth.py
+++ b/tests/models/test_dreambooth.py
@@ -22,3 +22,44 @@ def test_dreambooth_lora():
         (img,) = model(prompts="bench on the moon", num_images=1)
         assert img is not None
         assert isinstance(img, Image.Image)
+
+
+@skip_if_no_torch_cuda
+def test_dreambooth_lora_civit():
+    from pathlib import Path
+
+    # Dowload some weights from civit AI through their REST API:
+    HOWLS_CASTLE_CIVIT_URL = "https://civitai.com/api/v1/models/14605"
+
+    import requests
+
+    response = requests.get(HOWLS_CASTLE_CIVIT_URL)
+    assert response.status_code == 200
+    response_json = response.json()
+    assert len(response_json) > 0
+
+    first_model_version = response_json["modelVersions"][0]
+    assert first_model_version["baseModel"] == "SD 1.5"
+
+    weights_dir = Path("howls_castle") / "weights"
+    weights_name = "pytorch_lora_weights.safetensors"
+    full_weights_path = weights_dir / weights_name
+
+    import os
+
+    if not os.path.exists(str(full_weights_path)):
+        download_url = first_model_version["downloadUrl"]
+        weights_dir.mkdir(parents=True, exist_ok=True)
+
+        response = requests.get(download_url)
+        assert response.status_code == 200
+
+        with open(str(full_weights_path), "wb") as f:
+            f.write(response.content)
+
+    model = StableDiffusionLoRA(weights_dir=full_weights_path, model_name="runwayml/stable-diffusion-v1-5")
+    (img,) = model(prompts="a castle on a hillside", num_images=1)
+    # save this image
+    img.save("/home/scott/dev/nos/tests/test_output/test_dreambooth_lora_howls.png")
+    assert img is not None
+    assert isinstance(img, Image.Image)


### PR DESCRIPTION
Updating Lora weights currently requires that the model be registered under the custom model directory in `NOS_HOME`. For Civit AI models we need to specify the weights manually and create a config for the finetuned model in the DreamBooth hub.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
