### PR TITLE
Add Civit image generation to bot

### DIFF
--- a/examples/discord/bot.py
+++ b/examples/discord/bot.py
@@ -119,8 +119,6 @@ async def civit(ctx, *, prompt):
         thread = await ctx.message.create_thread(name=f"{model_name} ({message_id})")
         logger.debug(f"Created thread [id={thread.id}, name={thread.name}]")
 
-        # Save the thread id
-
         if not os.path.exists(str(full_weights_path)):
             download_url = first_model_version["downloadUrl"]
             weights_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Adds an interface to Discord bot for generating images using Civit LoRa weights:
`/civit $civit_url $prompt`

<img width="478" alt="Screenshot 2023-09-10 at 5 40 15 PM" src="https://github.com/autonomi-ai/nos/assets/106728726/04deda81-c2cf-4c90-b05d-0a58c8829fc4">


## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
