### PR TITLE
SDXL model support

### DIFF
--- a/nos/models/stable_diffusion.py
+++ b/nos/models/stable_diffusion.py
@@ -49,7 +49,7 @@ class StableDiffusion:
         "stabilityai/stable-diffusion-2-1": StableDiffusionConfig(
             model_name="stabilityai/stable-diffusion-2-1",
         ),
-        "stabilityai/sdxl": StableDiffusionConfig(
+        "stabilityai/stable-diffusion-xl-base-1.0": StableDiffusionConfig(
             model_name="stabilityai/stable-diffusion-xl-base-1.0",
         ),
     }
@@ -90,11 +90,11 @@ class StableDiffusion:
             self.scheduler = EulerDiscreteScheduler.from_pretrained(self.cfg.model_name, subfolder="scheduler")
         else:
             raise ValueError(f"Unknown scheduler: {scheduler}, choose from: ['ddim', 'euler-discrete']")
+
         self.pipe = DiffusionPipeline.from_pretrained(
             self.cfg.model_name,
             scheduler=self.scheduler,
             torch_dtype=self.dtype,
-            revision=self.revision,
         )
         self.pipe = self.pipe.to(self.device)
 


### PR DESCRIPTION
Add Stable Diffusion XL config, which is already available in `diffusers`. Test coverage available through parameter sweep in `test_stable_diffusion.py`. Only issue was a missing revision=fp16 in the huggingface model hub. Removing and using the dtype alone doesn't seem to make a difference to test results.

## Related issues

#324

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
