### PR TITLE
Build pypi package before push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,4 +29,6 @@ jobs:
       #   run: make docker-push-all
 
       - name: Build pypi packages
+        run: make dist
+      - name: Publish pypi packages
         run: make -f makefiles/Makefile.admin.mk create-pypi-release-test


### PR DESCRIPTION
Docker.yml doesn't build the dist before attempting to push to testpypi.

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
