### PR TITLE
Add build to requirements.txt

### DIFF
--- a/examples/discord/docker-compose.yml
+++ b/examples/discord/docker-compose.yml
@@ -1,23 +1,23 @@
 version: "3.8"
 
 services:
-  #bot:
-  #  image: autonomi/nos:latest-discord-app
-  #  build:
-  #    context: .
-  #    dockerfile: Dockerfile
-  #    args:
-  #      - BASE_IMAGE=autonomi/nos:latest-cpu
-  #  env_file:
-  #    - .env
-  #  environment:
-  #    - NOS_HOME=/app/.nos
-  #    - NOS_LOGGING_LEVEL=DEBUG
-  #  volumes:
-  #    - ~/.nosd:/app/.nos
-  #    - /dev/shm:/dev/shm
-  #  network_mode: host
-  #  ipc: host
+  bot:
+    image: autonomi/nos:latest-discord-app
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - BASE_IMAGE=autonomi/nos:latest-cpu
+    env_file:
+      - .env
+    environment:
+      - NOS_HOME=/app/.nos
+      - NOS_LOGGING_LEVEL=DEBUG
+    volumes:
+      - ~/.nosd:/app/.nos
+      - /dev/shm:/dev/shm
+    network_mode: host
+    ipc: host
 
   server:
     image: autonomi/nos:latest-gpu


### PR DESCRIPTION
`build` (required for `make dist`) does not seem to be included in `python<=3.10`, which is causing pypi build flows to build in github actions. I've added it to the main `requirements.txt` file for now to finish out the CI flow.

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
