### PR TITLE
Manually install pypi build dependencies

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,8 @@ jobs:
       # - name: Push docker images
       #   run: make docker-push-all
 
+      - name: Install dependencies
+        run: make develop-cpu
       - name: Build pypi packages
         run: make dist
       - name: Publish pypi packages


### PR DESCRIPTION
'build' package and others aren't currently being installed while we bypass `ci.yml`.

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
