### PR TITLE
Text-to-speech model support (e.g. `suno/bark`)

### DIFF
--- a/nos/models/__init__.py
+++ b/nos/models/__init__.py
@@ -17,6 +17,7 @@ from .openmmlab.mmdetection import MMDetection  # noqa: F401
 from .sam import SAM
 from .stable_diffusion import StableDiffusion  # noqa: F401
 from .super_resolution import SuperResolution  # noqa: F401
+from .tts import TextToSpeech  # noqa: F401
 from .whisper import Whisper  # noqa: F401
 from .whisperx import WhisperX  # noqa: F401
 from .yolox import YOLOX  # noqa: F401

--- a/nos/models/tts.py
+++ b/nos/models/tts.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+from typing import Any, List, Union
+
+import torch
+
+from nos.hub import HuggingFaceHubConfig
+
+
+@dataclass(frozen=True)
+class TextToSpeechConfig(HuggingFaceHubConfig):
+    pass
+
+
+class TextToSpeech:
+    """Text-to-speech models for speech generation.
+    https://huggingface.co/tasks/text-to-speech
+    """
+
+    configs = {
+        "suno/bark": TextToSpeechConfig(
+            model_name="suno/bark",
+        ),
+        "suno/bark-small": TextToSpeechConfig(
+            model_name="suno/bark-small",
+        ),
+    }
+
+    def __init__(self, model_name: str = "suno/bark-small"):
+        from transformers import AutoModel, AutoProcessor
+
+        try:
+            self.cfg = TextToSpeech.configs[model_name]
+        except KeyError:
+            raise ValueError(f"Invalid model_name: {model_name}, available models: {TextToSpeech.configs.keys()}")
+
+        if torch.cuda.is_available():
+            self.device = torch.device("cuda:0")
+            torch.backends.cuda.matmul.allow_tf32 = True
+        else:
+            self.device = torch.device("cpu")
+
+        model_name = self.cfg.model_name
+        self.processor = AutoProcessor.from_pretrained(model_name)
+        self.model = AutoModel.from_pretrained(model_name).to(self.device)
+
+    def __call__(self, prompts: Union[str, List[str]]) -> Any:
+        """Generate speech from text prompts."""
+        with torch.inference_mode():
+            inputs = self.processor(
+                text=prompts,
+                return_tensors="pt",
+            ).to(self.device)
+            return self.model.generate(**inputs, do_sample=True)

--- a/requirements/requirements.server.txt
+++ b/requirements/requirements.server.txt
@@ -7,4 +7,4 @@ ray[default]>=2.6.1
 safetensors>=0.3.0
 tabulate
 timm>=0.9.2
-transformers>=4.29.2
+transformers>=4.31.0

--- a/tests/models/test_tts.py
+++ b/tests/models/test_tts.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+import pytest
+
+from nos.test.utils import skip_if_no_torch_cuda
+
+
+@pytest.fixture
+def tts_model():
+    from nos.models import TextToSpeech  # noqa: F401
+
+    MODEL_NAME = "suno/bark-small"
+    yield TextToSpeech(model_name=MODEL_NAME)
+
+
+@skip_if_no_torch_cuda
+def test_tts_generate(tts_model):
+    transcription: Any = tts_model(
+        prompts=["Ask not what your country can do for you, ask what you can do for your country"]
+    )
+    assert transcription is not None


### PR DESCRIPTION
## Summary
 - added tests for `suno/bark` and `suno/bark-small` model

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [x] GPU/HW tests
