### PR TITLE
Locust load testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,5 @@ update-conda: ## Export conda environment
 	fi
 	conda env export --file conda/envs/$(CONDA_DEFAULT_ENV)/env.yml;
 
-# TODO (Scott): This still requires that the GPU container be started in the background
 test-locust:
 	locust -f tests/locustfile.py --config=tests/locust.conf

--- a/nos/models/dreambooth/dreambooth.py
+++ b/nos/models/dreambooth/dreambooth.py
@@ -6,6 +6,8 @@ from typing import Dict, List, Union
 import torch
 from PIL import Image
 
+from nos import hub
+from nos.common import Batch, ImageSpec, ImageT, TaskType
 from nos.hub.config import NOS_MODELS_DIR
 from nos.logging import logger
 
@@ -210,7 +212,6 @@ class StableDiffusionLoRA:
         ).images
 
 
-"""
 for model_name in StableDiffusionLoRA.configs.keys():
     logger.debug(f"Registering model: {model_name}")
     hub.register(
@@ -223,4 +224,3 @@ for model_name in StableDiffusionLoRA.configs.keys():
         inputs={"prompts": Batch[str, 1], "num_images": int, "height": int, "width": int},
         outputs={"images": Batch[ImageT[Image.Image, ImageSpec(shape=(None, None, 3), dtype="uint8")]]},
     )
-"""

--- a/tests/client/http/start_http_server.py
+++ b/tests/client/http/start_http_server.py
@@ -1,4 +1,3 @@
-# Create a test app to run load testing against:
 import uvicorn
 
 import nos
@@ -7,9 +6,7 @@ from nos.server.http._service import app
 
 # Init a nos backend for REST API:
 nos.init(runtime="gpu", logging_level="DEBUG")
-
 client = nos.InferenceClient()
-
 client.WaitForServer()
 assert client.IsHealthy()
 

--- a/tests/locustfile.py
+++ b/tests/locustfile.py
@@ -5,8 +5,6 @@ from nos.server.http._utils import encode_dict
 from nos.test.utils import NOS_TEST_IMAGE
 
 
-NOS_TEST_IMAGE = "/home/scott/dev/nos/tests/test_data/test.jpg"
-
 data = {
     "task": "custom",
     "model_name": "noop/process-images",


### PR DESCRIPTION
![Screenshot from 2023-09-27 15-56-36](https://github.com/autonomi-ai/nos/assets/106728726/bf31ee88-50df-4795-a138-8929b43715b4)

Set up a locustfile to spam embedding requests from a single worker against the REST API.
1. Start NOS REST API: `python tests/client/http/start_http_server.py`
2. Start locust tests: `make test-locust`
3. Navigate to locust UI to specify workers, spawn rate etc.

`uvicorn` apparently restricts script invocations to a single worker; if we want more clients hitting the same server we might need to move this to a subprocess call or do it manually in the CLI with workers > 1.

## Related issues

autonomi-ai/nos-internal#39 

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
