### PR TITLE
Huggingface Hub support for public/private `autonomi-ai` models

### DIFF
--- a/nos/hub/__init__.py
+++ b/nos/hub/__init__.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, List, Optional, Type
 from nos.common import FunctionSignature, ModelSpec, TaskType  # noqa: F401
 from nos.common.metaclass import SingletonMetaclass  # noqa: F401
 from nos.hub.config import HuggingFaceHubConfig, MMLabConfig, MMLabHub, NosHubConfig, TorchHubConfig  # noqa: F401
+from nos.hub.hf import hf_login  # noqa: F401
 from nos.logging import logger
 
 

--- a/nos/hub/hf.py
+++ b/nos/hub/hf.py
@@ -1,0 +1,16 @@
+import os
+
+from huggingface_hub import login
+
+from nos.logging import logger
+
+
+def hf_login(write_permission: bool = False):
+    """Login to huggingface hub."""
+    token = os.getenv("HUGGINGFACE_HUB_TOKEN", None)
+    if token is None:
+        raise ValueError("HUGGINGFACE_HUB_TOKEN is not set")
+    logger.debug(f"Logging into HF with token={token[:4]}...{token[-4:]}")
+    login(
+        token=token, write_permission=write_permission
+    )  # Login to HF (required for private repos with write permission)

--- a/nos/models/stable_diffusion.py
+++ b/nos/models/stable_diffusion.py
@@ -10,22 +10,18 @@ from nos.common.types import Batch, ImageSpec, ImageT
 from nos.hub import HuggingFaceHubConfig
 
 
-def get_model_id(name: str, shape: torch.Size, dtype: torch.dtype) -> str:
-    """Get model id from model name, shape and dtype."""
-    replacements = {"/": "-", " ": "-"}
-    for k, v in replacements.items():
-        name = name.replace(k, v)
-    shape = list(map(int, shape))
-    shape_str = "x".join([str(s) for s in shape])
-    precision_str = str(dtype).split(".")[-1]
-    return f"{name}_{shape_str}_{precision_str}"
+@dataclass(frozen=True)
+class StableDiffusionConfig(HuggingFaceHubConfig):
+    pass
 
 
 @dataclass(frozen=True)
-class StableDiffusionConfig(HuggingFaceHubConfig):
-    """Configuration for StableDiffusion model."""
+class StableDiffusionNeuronConfig(HuggingFaceHubConfig):
+    neuron_model_name: str = None
+    """Name of the neuron / neuronx model."""
 
-    pass
+    neuron_type: str = "neuronx"
+    """Type of neuron model, one of ['neuron', 'neuronx']."""
 
 
 class StableDiffusion:
@@ -46,6 +42,11 @@ class StableDiffusion:
         ),
         "stabilityai/stable-diffusion-xl-base-1-0": StableDiffusionConfig(
             model_name="stabilityai/stable-diffusion-xl-base-1.0",
+        ),
+        "autonomi-ai/stable-diffusion-xl-base-1-0-neuronx": StableDiffusionNeuronConfig(
+            model_name="stabilityai/stable-diffusion-xl-base-1.0",
+            neuron_model_name="autonomi-ai/stable-diffusion-xl-base-1.0-neuronx",
+            neuron_type="neuronx",
         ),
     }
 

--- a/tests/hub/test_hub_hf.py
+++ b/tests/hub/test_hub_hf.py
@@ -1,0 +1,15 @@
+import pytest
+
+from nos.logging import logger
+
+
+def test_hf_login():
+    import os
+
+    from nos.hub import hf_login
+
+    if os.getenv("HUGGINGFACE_HUB_TOKEN", None) is None:
+        logger.warning("HUGGINGFACE_HUB_TOKEN not set")
+        pytest.skip("HUGGINGFACE_HUB_TOKEN not set")
+
+    hf_login()


### PR DESCRIPTION
## Summary

This PR will allow us to download custom models from the autonomi-ai hub on huggingface (https://huggingface.co/autonomi-ai)

- added tests for huggingface login and custom SDXL model download from our hub

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
