### PR TITLE
Move release flow to a larger runner

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: large_runner
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Docker builds are failing on the standard workflow runners due to insufficient disk space. Trying on larger machine to see if this resolves the issue.

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
