### PR TITLE
Add cu118 release flow as a seperate job

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,8 +7,8 @@ on:
         - completed
 
 jobs:
-  push_to_registry:
-    name: Push Docker image to Docker Hub
+  push_cpu_gpu_to_registry:
+    name: Push CPU/GPU Docker image to Docker Hub
     runs-on: large_runner
     steps:
       - name: Check out the repo
@@ -20,10 +20,10 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build Docker images
-        run: make docker-build-all
-      - name: Push docker images
-        run: make docker-push-all
+      - name: Build CPU/GPU Docker images
+        run: make docker-build-cpu docker-build-gpu
+      - name: Push CPU/GPU Docker images
+        run: make docker-push-cpu docker-push-gpu
 
       - name: Install dependencies
         run: make develop-cpu
@@ -31,3 +31,39 @@ jobs:
         run: make dist
       - name: Publish pypi packages
         run: make -f makefiles/Makefile.admin.mk create-pypi-release-loose PYPI_USERNAME=${{ secrets.PYPI_USERNAME }} PYPI_PASSWORD=${{ secrets.PYPI_PASSWORD }}
+
+  push_cu118_to_registry:
+    needs: push_cpu_gpu_to_registry
+    name: Push cu118 Docker image to Docker Hub
+    runs-on: large_runner
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build cu118 Docker images
+        run: make docker-build-cu118
+      - name: Push cu118 Docker images
+        run: make docker-push-cu118
+
+  # push_multiplatform_to_registry:
+  #   needs: push_multiplatform_to_registry
+  #   name: Push multiplatform Docker image to Docker Hub
+  #   runs-on: large_runner
+  #   steps:
+  #     - name: Check out the repo
+  #       uses: actions/checkout@v2
+
+  #     - name: Log in to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  #     - name: Build and Push multiplatform Docker images
+  #       run: make docker-build-and-push-multiplatform-cpu-prod

--- a/makefiles/Makefile.base.mk
+++ b/makefiles/Makefile.base.mk
@@ -50,6 +50,8 @@ docker-build-gpu: agi-build-gpu
 docker-build-gpu-prod:
 	make agi-build-gpu AGIPACK_ARGS=--prod
 
+docker-build-cu118: agi-build-cu118
+
 docker-build-and-push-multiplatform-cpu:
 	agi-pack generate ${AGIPACK_ARGS} \
 		-c docker/agibuild.cpu.yaml \
@@ -63,7 +65,7 @@ docker-build-and-push-multiplatform-cpu-prod:
 	make .docker-build-and-push-multiplatform-cpu AGIPACK_ARGS=--prod
 
 docker-build-all: \
-	docker-build-cpu docker-build-gpu
+	docker-build-cpu docker-build-gpu docker-build-cu118
 
 docker-push-cpu:
 	make .docker-push-base \
@@ -73,8 +75,10 @@ docker-push-gpu:
 	make .docker-push-base \
 	TARGET=gpu
 
+docker-push-cu118: agi-push-cu118
+
 docker-push-all: \
-	docker-push-cpu docker-push-gpu docker-build-and-push-multiplatform-cpu
+	docker-push-cpu docker-push-gpu docker-push-cu118
 
 docker-test-cpu:
 	docker compose -f docker-compose.test.yml run --rm --build test-cpu


### PR DESCRIPTION
* Build targets for 118 multiplatform
* Add 118 multiplatform images to release flow as a dependent job
## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
