### PR TITLE
Fix `FunctionSignature.get_output_spec()` for automatically inspected methods

### DIFF
--- a/nos/hub/__init__.py
+++ b/nos/hub/__init__.py
@@ -1,6 +1,7 @@
+import inspect
 from dataclasses import field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import yaml
 from pydantic import ValidationError, root_validator
@@ -99,7 +100,7 @@ class Hub:
         init_args: Tuple[Any] = (),
         init_kwargs: Dict[str, Any] = {},  # noqa: B006
         inputs: Dict[str, Any] = {},  # noqa: B006
-        outputs: Dict[str, Any] = {},  # noqa: B006
+        outputs: Union[Any, Dict[str, Any], None] = None,  # noqa: B006
         **kwargs,
     ) -> ModelSpec:
         """Model registry decorator.

--- a/tests/common/test_common_spec.py
+++ b/tests/common/test_common_spec.py
@@ -277,7 +277,6 @@ def test_common_spec_signature():
         assert spec.name
         assert spec.task
         assert spec.default_signature.input_annotations is not None
-        assert spec.default_signature.output_annotations is not None
         logger.debug(f"{spec.name}, {spec.task}")
 
         if isinstance(spec.default_signature.input_annotations, dict):

--- a/tests/integrations/benchmark-pixeltable.md
+++ b/tests/integrations/benchmark-pixeltable.md
@@ -1,6 +1,25 @@
 ## GPU benchmarks
 
-### Timing records (0.1.0 - 2023-10-15)
+### Timing records (0.1.0rc2 - 2023-10-27)
+Timing records
+                      desc  elapsed    n  latency_ms     fps
+0             noop_294x240     1.14  168        6.79  147.37
+1             noop_640x480     1.17  168        6.96  143.59
+2            noop_1280x720     4.96  168       29.52   33.87
+3           noop_2880x1620    17.22  168      102.50    9.76
+4     yolox_medium_294x240     2.06  168       12.26   81.55
+5     yolox_medium_640x480     1.90  168       11.31   88.42
+6    yolox_medium_1280x720     8.51  168       50.65   19.74
+7   yolox_medium_2880x1620    20.87  168      124.23    8.05
+8       yolox_tiny_294x240     2.00  168       11.90   84.00
+9       yolox_tiny_640x480     1.73  168       10.30   97.11
+10     yolox_tiny_1280x720     7.38  168       43.93   22.76
+11    yolox_tiny_2880x1620    19.80  168      117.86    8.48
+12          openai_224x224     2.34  168       13.93   71.79
+13           sdv21_512x512     2.74    2     1370.00    0.73
+14          sdxl_1024x1024    13.72    2     6860.00    0.15
+
+### Timing records (0.1.0rc1 - 2023-10-15)
 ```bash
                       desc  elapsed    n  latency_ms     fps
 0             noop_294x240     1.09  168        6.49  154.13


### PR DESCRIPTION
## Summary

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
