### PR TITLE
Fix bug in twine upload

### DIFF
--- a/makefiles/Makefile.admin.mk
+++ b/makefiles/Makefile.admin.mk
@@ -24,7 +24,7 @@ create-pypi-release-loose:
 		echo "examining file: $$file"; \
 		if [ -f "$$file" ] && echo "$$file" | grep -qE "$(WHL_GREP_PATTERN)"; then \
 			echo "Uploading: $$file"; \
-			twine upload --repository "$$file" --username $(PYPI_USERNAME) --password $(PYPI_PASSWORD); \
+			twine upload "$$file" --username $(PYPI_USERNAME) --password $(PYPI_PASSWORD); \
 		fi; \
 	done
 	@echo "Upload completed"


### PR DESCRIPTION
Incomplete flag in `create-pypi-release-loose` causing twine upload to fail. Tested by reproducing the typo in the test flow and saw the same error, so pretty confident this will get resolved.

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
