### PR TITLE
create-pypi-release-loose -> create-pypi-release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build pypi packages
         run: make dist
       - name: Publish pypi packages
-        run: make -f makefiles/Makefile.admin.mk create-pypi-release-loose PYPI_USERNAME=${{ secrets.PYPI_USERNAME }} PYPI_PASSWORD=${{ secrets.PYPI_PASSWORD }}
+        run: make -f makefiles/Makefile.admin.mk create-pypi-release PYPI_USERNAME=${{ secrets.PYPI_USERNAME }} PYPI_PASSWORD=${{ secrets.PYPI_PASSWORD }}
 
   push_cu118_to_registry:
     needs: push_cpu_gpu_to_registry

--- a/makefiles/Makefile.admin.mk
+++ b/makefiles/Makefile.admin.mk
@@ -6,7 +6,7 @@ PYPI_PASSWORD :=
 
 WHL_GREP_PATTERN := .*\$(NOS_VERSION).*\.whl
 
-create-pypi-release-loose-test:
+create-pypi-release-test:
 	@echo "looking for nos whl file..."
 	@for file in dist/*; do \
 		echo "examining file: $$file"; \
@@ -18,7 +18,7 @@ create-pypi-release-loose-test:
 	@echo "Upload completed"
 
 
-create-pypi-release-loose:
+create-pypi-release:
 	@echo "looking for nos whl file..."
 	@for file in dist/*; do \
 		echo "examining file: $$file"; \
@@ -28,12 +28,6 @@ create-pypi-release-loose:
 		fi; \
 	done
 	@echo "Upload completed"
-
-create-pypi-release:  ## package, git tag/release and upload a release to PyP I
-	@echo -n "Are you sure you want to create a PyPI release? [y/N] " && read ans && [ $${ans:-N} = y ]
-	echo "Uploading dist/torch_nos-${NOS_VERSION}-py3-none-any.whl"
-	twine upload dist/torch_nos-${NOS_VERSION}-py3-none-any.whl
-	echo "Successfully created release ${NOS_VERSION}."
 
 create-tag:
 	git tag -a ${NOS_VERSION} -m "Release ${NOS_VERSION}"


### PR DESCRIPTION
No longer using the old `create-pypi-release`, no need for name confusion.

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
