### PR TITLE
Add agi pack to cu118 flow as well

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
 
+      - name: Install agi-pack
+        run: pip install agi-pack
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
These jobs run on different runners so `agi-pack` needs to be installed a second time.

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
