### PR TITLE
Support `env_file` for `docker-compose` rendering

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,9 +3,6 @@ name: Generate / Deploy Docs
 on:
   push:
     branches: [main]
-    paths:
-      - "nos/version.py"
-      - ".github/workflows/docs.yml"
   release:
     types: [released]
 

--- a/nos/cli/templates/docker-compose.serve.yml.j2
+++ b/nos/cli/templates/docker-compose.serve.yml.j2
@@ -8,6 +8,12 @@ services:
     environment:
       - NOS_HOME=/app/.nos
       - NOS_LOGGING_LEVEL={{ logging_level }}
+    {%- if env_file|length > 0 %}
+    env_file:
+      {%- for envf in env_file %}
+      - {{ envf }}
+      {%- endfor %}
+    {%- endif %}
     volumes:
       - ~/.nosd:/app/.nos
       - /dev/shm:/dev/shm
@@ -29,6 +35,12 @@ services:
       {%- if config %}
       - NOS_HUB_CATALOG_PATH=$NOS_HUB_CATALOG_PATH:{{ config }}
       {%- endif %}
+    {%- if env_file|length > 0 %}
+    env_file:
+      {%- for envf in env_file %}
+      - {{ envf }}
+      {%- endfor %}
+    {%- endif %}
     volumes:
       - ~/.nosd:/app/.nos
       - /dev/shm:/dev/shm


### PR DESCRIPTION
This PR adds support for `env_file` in `docker-compose` rendering. This is useful for passing secrets / environment variables to the serving container. For cloud deployments, this will still require manaully syncing the `.env` file to the cloud instance before running `nos serve`.

<!-- Thank you for your contribution! Please review https://github.com/autonomi-ai/nos/blob/main/docs/CONTRIBUTING.md before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Summary

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
