### PR TITLE
Support file-uploads with new HTTP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you want to simply use a light-weight NOS client and run inference on your lo
 
 ## 🔥 Quickstart / Show me the code
 
-### Image Generation as-a-Service
+### 🏞️ Image Generation (Stable-Diffusion-as-a-Service)
 
 
 <table>
@@ -78,21 +78,21 @@ curl \
 -X POST http://localhost:8000/infer \
 -H 'Content-Type: application/json' \
 -d '{
-      "model_id": "stabilityai/stable-diffusion-xl-base-1-0",
-      "inputs": {
-          "prompts": ["fox jumped over the moon"],
-          "width": 1024,
-          "height": 1024,
-          "num_images": 1
-      }
-    }'
+    "model_id": "stabilityai/stable-diffusion-xl-base-1-0",
+    "inputs": {
+        "prompts": ["fox jumped over the moon"],
+        "width": 1024,
+        "height": 1024,
+        "num_images": 1
+    }
+}'
 ```
 
 </td>
 </tr>
 </table>
 
-### Text & Image Embedding-as-a-Service (CLIP-as-a-Service)
+### 🧠 Text & Image Embedding (CLIP-as-a-Service)
 
 <table>
 <tr>
@@ -119,12 +119,86 @@ curl \
 -X POST http://localhost:8000/infer \
 -H 'Content-Type: application/json' \
 -d '{
-      "model_id": "openai/clip-vit-base-patch32",
-      "method": "encode_text",
-      "inputs": {
-          "texts": ["fox jumped over the moon"]
-      }
-    }'
+    "model_id": "openai/clip-vit-base-patch32",
+    "method": "encode_text",
+    "inputs": {
+        "texts": ["fox jumped over the moon"]
+    }
+}'
+```
+
+</td>
+</tr>
+</table>
+
+### 🎙️ Audio Transcription (Whisper-as-a-Service)
+
+<table>
+<tr>
+<td> gRPC API ⚡ </td>
+<td> REST API </td>
+</tr>
+<tr>
+<td>
+
+```python
+from pathlib import Path
+from nos.client import Client
+
+client = Client("[::]:50051")
+
+model = client.Module("openai/whisper-large-v2")
+response = model(path=Path("audio.wav"))
+# {"chunks": ...}
+```
+
+</td>
+<td>
+
+```bash
+curl \
+-X POST http://localhost:8000/infer_file \
+-H 'accept: application/json' \
+-H 'Content-Type: multipart/form-data' \
+-F 'model_id=openai/whisper-large-v2' \
+-F 'file=@audio.wav'
+```
+
+</td>
+</tr>
+</table>
+
+### 🧐 Object Detection (YOLOX-as-a-Service)
+
+<table>
+<tr>
+<td> gRPC API ⚡ </td>
+<td> REST API </td>
+</tr>
+<tr>
+<td>
+
+```python
+from pathlib import Path
+from nos.client import Client
+
+client = Client("[::]:50051")
+
+model = client.Module("yolox/medium")
+response = model(images=[Image.open("image.jpg")])
+# {"bboxes": ..., "scores": ..., "labels": ...}
+```
+
+</td>
+<td>
+
+```bash
+curl \
+-X POST http://localhost:8000/infer_file \
+-H 'accept: application/json' \
+-H 'Content-Type: multipart/form-data' \
+-F 'model_id=yolox/medium' \
+-F 'file=@image.jpg'
 ```
 
 </td>
@@ -132,7 +206,7 @@ curl \
 </table>
 
 
-## 📂 Directory Structure
+## 🗂️ Directory Structure
 
 ```bash
 ├── docker         # Dockerfile for CPU/GPU servers


### PR DESCRIPTION
 This PR supports file-uploads for various models (object detection,
 whisper etc) where the user is allowed to upload a file and get the
inference results. The file-upload is supported by the new HTTP endpoint `/infer_file` POST request. The request body should contain the file data and the request headers should contain the `model_id` and the `method` (optional), with the `file`. A few examples have been added to the `README` along with HTTP client-side tests to verify the functionality.

<!-- Thank you for your contribution! Please review https://github.com/autonomi-ai/nos/blob/main/docs/CONTRIBUTING.md before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Summary

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
