### PR TITLE
Fix production FastAPI configuration

### DIFF
--- a/nos/cli/templates/docker-compose.serve.yml.j2
+++ b/nos/cli/templates/docker-compose.serve.yml.j2
@@ -8,6 +8,9 @@ services:
     environment:
       - NOS_HOME=/app/.nos
       - NOS_LOGGING_LEVEL={{ logging_level }}
+      {%- if http_env %}
+      - NOS_HTTP_ENV={{ http_env }}
+      {%- endif %}
     {%- if env_file|length > 0 %}
     env_file:
       {%- for envf in env_file %}

--- a/nos/constants.py
+++ b/nos/constants.py
@@ -15,12 +15,10 @@ NOS_MODELS_DIR.mkdir(parents=True, exist_ok=True)
 NOS_LOG_DIR.mkdir(parents=True, exist_ok=True)
 NOS_TMP_DIR.mkdir(parents=True, exist_ok=True)
 
-DEFAULT_GRPC_PORT = int(os.getenv("NOS_GRPC_PORT", 50051))
 DEFAULT_HTTP_PORT = int(os.getenv("NOS_HTTP_PORT", 8000))
+DEFAULT_GRPC_PORT = int(os.getenv("NOS_GRPC_PORT", 50051))
 GRPC_MAX_MESSAGE_LENGTH = 32 * 1024 * 1024  # 32 MB
-
-NOS_GRPC_MAX_WORKER_THREADS = int(os.getenv("NOS_GRPC_MAX_WORKER_THREADS", 4))
-NOS_HTTP_MAX_WORKER_THREADS = int(os.getenv("NOS_HTTP_MAX_WORKER_THREADS", 4))
+GRPC_MAX_WORKER_THREADS = int(os.getenv("NOS_GRPC_MAX_WORKER_THREADS", 4))
 
 NOS_PROFILING_ENABLED = bool(int(os.getenv("NOS_PROFILING_ENABLED", "0")))
 NOS_MEMRAY_ENABLED = bool(int(os.getenv("NOS_MEMRAY_ENABLED", "0")))

--- a/nos/server/_service.py
+++ b/nos/server/_service.py
@@ -16,7 +16,7 @@ from nos.common.shm import NOS_SHM_ENABLED, SharedMemoryDataDict, SharedMemoryTr
 from nos.constants import (  # noqa F401
     DEFAULT_GRPC_PORT,  # noqa F401
     GRPC_MAX_MESSAGE_LENGTH,
-    NOS_GRPC_MAX_WORKER_THREADS,
+    GRPC_MAX_WORKER_THREADS,
     NOS_PROFILING_ENABLED,
 )
 from nos.exceptions import ModelNotFoundError
@@ -274,7 +274,7 @@ class InferenceServiceImpl(nos_service_pb2_grpc.InferenceServiceServicer, Infere
             context.abort(grpc.StatusCode.INTERNAL, "Internal Server Error")
 
 
-def serve(address: str = f"[::]:{DEFAULT_GRPC_PORT}", max_workers: int = NOS_GRPC_MAX_WORKER_THREADS) -> None:
+def serve(address: str = f"[::]:{DEFAULT_GRPC_PORT}", max_workers: int = GRPC_MAX_WORKER_THREADS) -> None:
     """Start the gRPC server."""
     from concurrent import futures
 


### PR DESCRIPTION
## Summary

This PR adds the optional `NOS_HTTP_ENV` flag to the HTTP gateway service. This flag allows the user to switch the FastAPI application to production mode.

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
