### PR TITLE
Support model streaming responses with new `Stream` gRPC service

### DIFF
--- a/nos/cli/predict.py
+++ b/nos/cli/predict.py
@@ -18,7 +18,7 @@ import rich.table
 import typer
 
 from nos.client import Client
-from nos.common.exceptions import NosClientException
+from nos.common.exceptions import ClientException
 
 
 predict_cli = typer.Typer(name="predict", help="NOS gRPC Prediction CLI.", no_args_is_help=True)
@@ -51,7 +51,7 @@ def _list_models(ctx: typer.Context):
     try:
         models: List[str] = ctx.obj.client.ListModels()
         console.print(models)
-    except NosClientException as exc:
+    except ClientException as exc:
         console.print(f"[red] ✗ Failed to list models ({exc}).[/red]")
 
 
@@ -75,7 +75,7 @@ def _predict_img2vec(
             st = time.perf_counter()
             response = ctx.obj.client.Run(model_id, inputs={"images": [img]})
             end = time.perf_counter()
-        except NosClientException as exc:
+        except ClientException as exc:
             console.print(f"[red] ✗ Failed to encode image. [/red]\n[bold red]{exc}[/bold red]")
             return
     console.print(
@@ -101,7 +101,7 @@ def _predict_txt2vec(
             st = time.perf_counter()
             response = ctx.obj.client.Run(model_id, inputs={"texts": [prompt]})
             end = time.perf_counter()
-        except NosClientException as exc:
+        except ClientException as exc:
             console.print(f"[red] ✗ Failed to generate image. [/red]\n[bold red]{exc}[/bold red]")
             return
     console.print(
@@ -137,7 +137,7 @@ def _predict_txt2img(
                 },
             )
             end = time.perf_counter()
-        except NosClientException as exc:
+        except ClientException as exc:
             console.print(f"[red] ✗ Failed to generate image. [/red]\n[bold red]{exc}[/bold red]")
             return
     console.print(
@@ -168,7 +168,7 @@ def _predict_img2bbox(
             console.print(
                 f"[bold green] ✓ Predicted bounding boxes (bboxes={bboxes[0].shape}, scores={scores[0].shape}, labels={labels[0].shape}, time=~{(end - st) * 1e3:.1f}ms) [/bold green]"
             )
-        except NosClientException as exc:
+        except ClientException as exc:
             console.print(f"[red] ✗ Failed to predict bounding boxes. [/red]\n[bold red]{exc}[/bold red]")
             return
 
@@ -192,7 +192,7 @@ def _predict_segmentation(
             st = time.perf_counter()
             response = ctx.obj.client.Run(model_id, inputs={"images": [img]})
             time.perf_counter()
-        except NosClientException as exc:
+        except ClientException as exc:
             console.print(f"[red] ✗ Failed to predict segmentations. [/red]\n[bold red]{exc}[/bold red]")
             return
 

--- a/nos/client/__init__.py
+++ b/nos/client/__init__.py
@@ -1,5 +1,5 @@
 from nos.client.grpc import Client  # noqa: F401
-from nos.common.exceptions import NosClientException  # noqa: F401
+from nos.common.exceptions import ClientException  # noqa: F401
 from nos.common.spec import FunctionSignature, ModelSpec  # noqa: F401
 from nos.common.tasks import TaskType  # noqa: F401
 from nos.common.types import Batch, EmbeddingSpec, ImageSpec, ImageT, TensorSpec, TensorT  # noqa: F401

--- a/nos/client/grpc.py
+++ b/nos/client/grpc.py
@@ -5,7 +5,7 @@ import time
 from dataclasses import dataclass, field
 from functools import cached_property, lru_cache, partial
 from pathlib import Path
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, Iterable, List
 
 import grpc
 import numpy as np
@@ -14,10 +14,10 @@ from PIL import Image
 
 from nos.common import FunctionSignature, ModelSpec, TensorSpec, dumps, loads
 from nos.common.exceptions import (
-    NosClientException,
-    NosInferenceException,
-    NosInputValidationException,
-    NosServerReadyException,
+    ClientException,
+    InferenceException,
+    InputValidationException,
+    ServerReadyException,
 )
 from nos.common.shm import NOS_SHM_ENABLED, SharedMemoryTransportManager
 from nos.constants import DEFAULT_GRPC_PORT, GRPC_MAX_MESSAGE_LENGTH, NOS_PROFILING_ENABLED
@@ -126,7 +126,7 @@ class Client:
             try:
                 self._stub = nos_service_pb2_grpc.InferenceServiceStub(self._channel)
             except Exception as e:
-                raise NosServerReadyException(f"Failed to connect to server ({e})", e)
+                raise ServerReadyException(f"Failed to connect to server ({e})", e)
         assert self._channel
         assert self._stub
         return self._stub
@@ -143,7 +143,7 @@ class Client:
             response: nos_service_pb2.PingResponse = self.stub.Ping(empty_pb2.Empty())
             return response.status == "ok"
         except grpc.RpcError as e:
-            raise NosServerReadyException(f"Failed to ping server (details={e.details()})", e)
+            raise ServerReadyException(f"Failed to ping server (details={e.details()})", e)
 
     def WaitForServer(self, timeout: int = 60, retry_interval: int = 5) -> None:
         """Ping the gRPC server for health.
@@ -163,7 +163,7 @@ class Client:
             except Exception:
                 logger.warning("Waiting for server to start... (elapsed={:.0f}s)".format(time.time() - st))
                 time.sleep(retry_interval)
-        raise NosServerReadyException("Failed to ping server.")
+        raise ServerReadyException("Failed to ping server.")
 
     def GetServiceVersion(self) -> str:
         """Get service version.
@@ -177,7 +177,7 @@ class Client:
             response: nos_service_pb2.ServiceInfoResponse = self.stub.GetServiceInfo(empty_pb2.Empty())
             return response.version
         except grpc.RpcError as e:
-            raise NosServerReadyException(f"Failed to get service info (details={e.details()})", e)
+            raise ServerReadyException(f"Failed to get service info (details={e.details()})", e)
 
     def GetServiceRuntime(self) -> str:
         """Get service runtime.
@@ -191,7 +191,7 @@ class Client:
             response: nos_service_pb2.ServiceInfoResponse = self.stub.GetServiceInfo(empty_pb2.Empty())
             return response.runtime
         except grpc.RpcError as e:
-            raise NosServerReadyException(f"Failed to get service info (details={e.details()})", e)
+            raise ServerReadyException(f"Failed to get service info (details={e.details()})", e)
 
     def CheckCompatibility(self) -> bool:
         """Check if the service version is compatible with the client.
@@ -205,7 +205,7 @@ class Client:
         # until we have tests for client-server compatibility.
         is_compatible = self.GetServiceVersion() == __version__
         if not is_compatible:
-            raise NosClientException(
+            raise ClientException(
                 f"Client-Server version mismatch (client={__version__}, server={self.GetServiceVersion()})"
             )
         return is_compatible
@@ -223,7 +223,7 @@ class Client:
             models: List[str] = loads(response.response_bytes)
             return list(models)
         except grpc.RpcError as e:
-            raise NosClientException(f"Failed to list models (details={e.details()})", e)
+            raise ClientException(f"Failed to list models (details={e.details()})", e)
 
     def GetModelInfo(self, model_id: str) -> ModelSpec:
         """Get the relevant model information from the model name.
@@ -241,7 +241,7 @@ class Client:
             model_spec: ModelSpec = loads(response.response_bytes)
             return model_spec
         except grpc.RpcError as e:
-            raise NosClientException(f"Failed to get model info (details={(e.details())})", e)
+            raise ClientException(f"Failed to get model info (details={(e.details())})", e)
 
     @lru_cache(maxsize=8)  # noqa: B019
     def Module(self, model_id: str, shm: bool = False) -> "Module":
@@ -297,7 +297,7 @@ class Client:
                     )
             return Path(loads(response.response_bytes)["filename"])
         except grpc.RpcError as e:
-            raise NosClientException(f"Failed to upload file (details={e.details()})", e)
+            raise ClientException(f"Failed to upload file (details={e.details()})", e)
 
     def _delete_file(self, path: Path) -> None:
         """Delete a file from the server.
@@ -310,7 +310,7 @@ class Client:
         try:
             self.stub.DeleteFile(nos_service_pb2.GenericRequest(request_bytes=dumps({"filename": str(path)})))
         except grpc.RpcError as e:
-            raise NosClientException(f"Failed to delete file (details={e.details()})", e)
+            raise ClientException(f"Failed to delete file (details={e.details()})", e)
 
     @contextlib.contextmanager
     def UploadFile(self, path: Path, chunk_size: int = 4 * MB_BYTES) -> Path:
@@ -348,6 +348,7 @@ class Client:
             inputs (Dict[str, Any]): Inputs to the model ("images", "texts", "prompts" etc) as
                 defined in the ModelSpec.signature.
             method (str, optional): Method to call on the model. Defaults to None.
+            stream (bool, optional): Stream the response. Defaults to False.
             shm (bool, optional): Enable shared memory transport. Defaults to False.
         Returns:
             nos_service_pb2.GenericResponse: Inference response.
@@ -356,6 +357,18 @@ class Client:
         """
         module: Module = self.Module(model_id, shm=shm)
         return module(**inputs, _method=method)
+
+    def Stream(
+        self,
+        model_id: str,
+        inputs: Dict[str, Any],
+        method: str = None,
+        shm: bool = False,
+    ) -> Iterable[nos_service_pb2.GenericResponse]:
+        """Run module in streaming mode."""
+        assert shm is False, "Shared memory transport is not supported for streaming yet."
+        module: Module = self.Module(model_id, shm=shm)
+        return module(**inputs, _method=method, _stream=True)
 
 
 @dataclass
@@ -453,7 +466,7 @@ class Module:
         if method is None:
             method = self._spec.default_method
         if method not in self._spec.signature:
-            raise NosInferenceException(f"Method {method} not found in spec signature.")
+            raise InferenceException(f"Method {method} not found in spec signature.")
         sig: FunctionSignature = self._spec.signature[method]
         inputs = FunctionSignature.validate(inputs, sig.parameters)
 
@@ -587,15 +600,16 @@ class Module:
                 logger.debug(f"Unregistered shm [{self._shm_objects}]")
             except grpc.RpcError as e:
                 logger.error(f"Failed to unregister shm [{self._shm_objects}], error: {e.details()}")
-                raise NosClientException(f"Failed to unregister shm [{self._shm_objects}]", e)
+                raise ClientException(f"Failed to unregister shm [{self._shm_objects}]", e)
 
-    def __call__(self, _method: str = None, **inputs: Dict[str, Any]) -> Dict[str, Any]:
+    def __call__(self, _method: str = None, _stream: bool = False, **inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Call the instantiated module/model.
 
         Args:
+            _method (str, optional): Method to call on the model. Defaults to None.
+            _stream (bool, optional): Stream the response. Defaults to False.
             **inputs (Dict[str, Any]): Inputs to the model ("images", "texts", "prompts" etc) as
                 defined in ModelSpec.signature.
-            _method (str, optional): Method to call on the model. Defaults to None.
         Returns:
             Dict[str, Any]: Inference response.
         Raises:
@@ -612,40 +626,59 @@ class Module:
             inputs = self._encode(inputs, method=_method)
         except Exception as e:
             logger.error(f"Failed to encode inputs [model={self.id}, method={_method}, inputs={inputs}, e={e}]")
-            raise NosInputValidationException(
+            raise InputValidationException(
                 f"Failed to encode inputs [model={self.id}, method={_method}, inputs={inputs}, e={e}]", e
             )
         if NOS_PROFILING_ENABLED:
             logger.debug(f"Encoded inputs [model={self.id}, elapsed={(time.perf_counter() - st) * 1e3:.1f}ms]")
 
-        try:
-            # Prepare the request
-            request = nos_service_pb2.GenericRequest(
-                request_bytes=dumps(
-                    {
-                        "id": self._spec.id,
-                        "method": _method,
-                        "inputs": inputs,
-                    }
-                )
+        # Prepare the request
+        request = nos_service_pb2.GenericRequest(
+            request_bytes=dumps(
+                {
+                    "id": self._spec.id,
+                    "method": _method,
+                    "inputs": inputs,
+                }
             )
+        )
+        try:
             # Execute the request
             st = time.perf_counter()
             logger.debug(f"Executing request [model={self.id}]")
-            response: nos_service_pb2.GenericResponse = self.stub.Run(request)
+            if not _stream:
+                response: nos_service_pb2.GenericResponse = self.stub.Run(request)
+            else:
+                response: Iterable[nos_service_pb2.GenericResponse] = self.stub.Stream(request)
             if NOS_PROFILING_ENABLED:
                 logger.debug(f"Executed request [model={self.id}, elapsed={(time.perf_counter() - st) * 1e3:.1f}ms]")
         except grpc.RpcError as e:
             logger.error(f"Run() failed [details={e.details()}, inputs={inputs.keys()}]")
-            raise NosInferenceException(f"Run() failed [model={self.id}, details={e.details()}]", e)
+            raise InferenceException(f"Run() failed [model={self.id}, details={e.details()}]", e)
 
-        # Decode the response
+        # Decode / stream the response
         st = time.perf_counter()
         try:
-            response = self._decode(response.response_bytes)
+            if not _stream:
+                response = self._decode(response.response_bytes)
+            else:
+                return _StreamingModuleResponse(response, self._decode)
         except Exception as e:
             logger.error(f"Failed to decode response [model={self.id}, e={e}]")
-            raise NosClientException(f"Failed to decode response [model={self.id}, e={e}]", e)
+            raise ClientException(f"Failed to decode response [model={self.id}, e={e}]", e)
         if NOS_PROFILING_ENABLED:
             logger.debug(f"Decoded response [model={self.id}, elapsed={(time.perf_counter() - st) * 1e3:.1f}ms]")
         return response
+
+
+@dataclass
+class _StreamingModuleResponse:
+    response: Iterable[nos_service_pb2.GenericResponse]
+    fn: Callable
+
+    def __iter__(self) -> Any:
+        return self
+
+    def __next__(self) -> Any:
+        resp = next(self.response)
+        return self.fn(resp.response_bytes)

--- a/nos/common/__init__.py
+++ b/nos/common/__init__.py
@@ -13,7 +13,7 @@ from .tasks import TaskType
 from .types import Batch, EmbeddingSpec, ImageSpec, ImageT, TensorSpec, TensorT
 
 
-def tqdm(iterable: Any = None, *args, **kwargs) -> Any:
+def tqdm(iterable: Any = None, *args, skip: int = 0, **kwargs) -> Any:
     """Wrapper around tqdm that allows for a duration to be
     specified instead of an iterable
 
@@ -38,6 +38,8 @@ def tqdm(iterable: Any = None, *args, **kwargs) -> Any:
         st_ms = time.perf_counter() * 1_000
         while True:
             now_ms = time.perf_counter() * 1_000
+            if skip > 0 and idx < skip:
+                st_ms = now_ms
             elapsed_ms = now_ms - st_ms
             if elapsed_ms >= duration_ms:
                 return

--- a/nos/common/exceptions.py
+++ b/nos/common/exceptions.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
-class NosClientException(Exception):
+class ClientException(Exception):
     """Base exception for the nos client."""
 
     message: str
@@ -15,21 +15,21 @@ class NosClientException(Exception):
         return f"{self.message}"
 
 
-class NosServerReadyException(NosClientException):
+class ServerReadyException(ClientException):
     """Exception raised when the server is not ready."""
 
     def __str__(self) -> str:
         return f"Server not ready. {self.message}"
 
 
-class NosInputValidationException(NosClientException):
+class InputValidationException(ClientException):
     """Exception raised when input validation fails."""
 
     def __str__(self) -> str:
         return f"Input validation failed. {self.message}"
 
 
-class NosInferenceException(NosClientException):
+class InferenceException(ClientException):
     """Exception raised when inference fails."""
 
     def __str__(self) -> str:

--- a/nos/common/spec.py
+++ b/nos/common/spec.py
@@ -11,7 +11,7 @@ from pydantic import validator
 from pydantic.dataclasses import dataclass
 
 from nos.common.cloudpickle import dumps, loads
-from nos.common.exceptions import NosInputValidationException
+from nos.common.exceptions import InputValidationException
 from nos.common.runtime import RuntimeEnv
 from nos.common.tasks import TaskType
 from nos.common.types import Batch, EmbeddingSpec, ImageSpec, ImageT, TensorSpec, TensorT  # noqa: F401
@@ -188,7 +188,7 @@ class FunctionSignature:
         """Validate the input dict against the defined signature (input or output)."""
         # TOFIX (spillai): This needs to be able to validate using args/kwargs instead
         if not set(inputs.keys()).issubset(set(sig.keys())):  # noqa: W503
-            raise NosInputValidationException(
+            raise InputValidationException(
                 f"Invalid inputs, provided={set(inputs.keys())}, expected={set(sig.keys())}."
             )
         # TODO (spillai): Validate input types and shapes.

--- a/nos/common/tasks.py
+++ b/nos/common/tasks.py
@@ -23,6 +23,7 @@ class TaskType(str, Enum):
     TEXT_EMBEDDING = "text_embedding"
     """Text embedding."""
 
+    TEXT_GENERATION = "text_generation"
     AUDIO_TRANSCRIPTION = "audio_transcription"
 
     CUSTOM = "custom"

--- a/nos/models/__init__.py
+++ b/nos/models/__init__.py
@@ -12,6 +12,7 @@ from ._noop import NoOp  # noqa: F401
 from .blip import BLIP  # noqa: F401
 from .clip import CLIP  # noqa: F401
 from .faster_rcnn import FasterRCNN  # noqa: F401
+from .llama2_chat import Llama2Chat  # noqa: F401
 from .monodepth import MonoDepth  # noqa: F401
 from .owlvit import OwlViT  # noqa: F401
 from .sam import SAM

--- a/nos/models/_noop.py
+++ b/nos/models/_noop.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Union
+from typing import Iterable, List, Union
 
 import numpy as np
 from PIL import Image
@@ -23,6 +23,12 @@ class NoOp:
     def process_file(self, path: Path) -> bool:
         assert path.exists(), f"File not found: {path}"
         return True
+
+    def stream_texts(self, texts: List[str]) -> Iterable[str]:
+        for line in texts:
+            yield line.rstrip()
+        for line in Path(__file__).open("r").readlines():
+            yield line.rstrip()
 
 
 # Register noop model separately for each method
@@ -55,6 +61,13 @@ hub.register(
     NoOp,
     method="process_file",
 )
+hub.register(
+    "noop/stream-texts",
+    TaskType.CUSTOM,
+    NoOp,
+    outputs=Iterable[str],
+    method="stream_texts",
+)
 
 # Register model with multiple methods under the same name
 hub.register(
@@ -83,4 +96,10 @@ hub.register(
     TaskType.CUSTOM,
     NoOp,
     method="process_file",
+)
+hub.register(
+    "noop/process",
+    TaskType.CUSTOM,
+    NoOp,
+    method="stream_texts",
 )

--- a/nos/models/llama2_chat.py
+++ b/nos/models/llama2_chat.py
@@ -1,0 +1,139 @@
+import time
+from dataclasses import dataclass
+from threading import Thread
+from typing import Iterable, List, Optional, Tuple
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, TextIteratorStreamer
+
+from nos import hub
+from nos.common import TaskType
+from nos.hub import HuggingFaceHubConfig, hf_login
+
+
+@dataclass(frozen=True)
+class Llama2ChatConfig(HuggingFaceHubConfig):
+    """Llama2 chat model configuration."""
+
+    max_new_tokens: int = 2048
+    """Maximum number of tokens to generate."""
+
+    max_input_token_length: int = 4096
+    """Maximum number of tokens in the input."""
+
+    compute_dtype: str = "float16"
+    """Compute type for the model."""
+
+    needs_auth: bool = False
+    """Whether the model needs authentication."""
+
+
+class Llama2Chat:
+    configs = {
+        "meta-llama/Llama-2-7b-chat-hf": Llama2ChatConfig(
+            model_name="meta-llama/Llama-2-7b-chat-hf",
+            compute_dtype="float16",
+            needs_auth=True,
+        ),
+        "HuggingFaceH4/zephyr-7b-beta": Llama2ChatConfig(
+            model_name="HuggingFaceH4/zephyr-7b-beta",
+            compute_dtype="float16",
+        ),
+        "HuggingFaceH4/tiny-random-LlamaForCausalLM": Llama2ChatConfig(
+            model_name="HuggingFaceH4/tiny-random-LlamaForCausalLM",
+            compute_dtype="float16",
+        ),
+    }
+
+    def __init__(self, model_name: str = "HuggingFaceH4/zephyr-7b-beta"):
+        from nos.logging import logger
+
+        try:
+            self.cfg = Llama2Chat.configs[model_name]
+        except KeyError:
+            raise ValueError(f"Invalid model_name: {model_name}, available models: {Llama2ChatConfig.configs.keys()}")
+
+        if torch.cuda.is_available():
+            self.device_str = "cuda"
+        else:
+            self.device_str = "cpu"
+        self.device = torch.device(self.device_str)
+        use_auth_token = hf_login() if self.cfg.needs_auth else None
+        self.model = AutoModelForCausalLM.from_pretrained(
+            self.cfg.model_name,
+            torch_dtype=getattr(torch, self.cfg.compute_dtype),
+            use_auth_token=use_auth_token,
+            device_map=self.device_str,
+        )
+        self.tokenizer = AutoTokenizer.from_pretrained(self.cfg.model_name, use_auth_token=use_auth_token)
+        self.tokenizer.use_default_system_prompt = False
+        self.logger = logger
+
+    def chat(
+        self,
+        message: str,
+        system_prompt: str,
+        chat_history: Optional[List[Tuple[str, str]]] = None,
+        max_new_tokens: int = 1024,
+        temperature: float = 0.6,
+        top_p: float = 0.9,
+        top_k: int = 50,
+        repetition_penalty: float = 1.2,
+        num_beams: int = 1,
+    ) -> Iterable[str]:
+        """Chat with the model."""
+        conversation = []
+        if system_prompt:
+            conversation.append({"role": "system", "content": system_prompt})
+        if chat_history:
+            for user, assistant in chat_history:
+                conversation.extend([{"role": "user", "content": user}, {"role": "assistant", "content": assistant}])
+        conversation.append({"role": "user", "content": message})
+
+        input_ids = self.tokenizer.apply_chat_template(conversation, return_tensors="pt")
+        if input_ids.shape[1] > self.cfg.max_input_token_length:
+            input_ids = input_ids[:, -self.cfg.max_input_token_length :]
+            self.logger.warning(
+                f"Trimmed input from conversation as it was longer than {self.cfg.max_input_token_length} tokens."
+            )
+        input_ids = input_ids.to(self.model.device)
+
+        streamer = TextIteratorStreamer(self.tokenizer, timeout=10.0, skip_prompt=True, skip_special_tokens=True)
+        generate_kwargs = dict(
+            {"input_ids": input_ids},
+            streamer=streamer,
+            max_new_tokens=max_new_tokens,
+            do_sample=True,
+            top_p=top_p,
+            top_k=top_k,
+            temperature=temperature,
+            num_beams=num_beams,
+            repetition_penalty=repetition_penalty,
+        )
+        t = Thread(target=self.model.generate, kwargs=generate_kwargs)
+        t.start()
+
+        start_t = None
+        for idx, text in enumerate(streamer):
+            yield text
+            # We only measure the time after the first token is generated
+            if start_t is None:
+                start_t = time.perf_counter()
+            if idx > 0:
+                self.logger.debug(
+                    f"""tok/s={idx / (time.perf_counter() - start_t):.2f}, """
+                    f"""memory={torch.cuda.memory_allocated(device=self.model.device) / 1024 ** 2:.2f} MB, """
+                    f"""allocated={torch.cuda.max_memory_allocated(device=self.model.device) / 1024 ** 2:.2f} MB, """
+                    f"""peak={torch.cuda.max_memory_reserved(device=self.model.device) / 1024 ** 2:.2f} MB, """
+                )
+
+
+for model_name in Llama2Chat.configs:
+    cfg = Llama2Chat.configs[model_name]
+    hub.register(
+        model_name,
+        TaskType.TEXT_GENERATION,
+        Llama2Chat,
+        init_args=(model_name,),
+        method="chat",
+    )

--- a/nos/proto/nos_service.proto
+++ b/nos/proto/nos_service.proto
@@ -44,6 +44,9 @@ service InferenceService {
   // Run the inference request
   rpc Run(GenericRequest) returns (GenericResponse) {}
 
+  // Stream the inference response
+  rpc Stream(GenericRequest) returns (stream GenericResponse) {}
+
   // Register shared memory
   rpc RegisterSystemSharedMemory(GenericRequest) returns (GenericResponse) {}
 

--- a/nos/test/conftest.py
+++ b/nos/test/conftest.py
@@ -263,14 +263,14 @@ def http_client_with_gpu_backend(grpc_server_docker_runtime_gpu):  # noqa: F811
 
 # Needed for referencing relevant pytest fixtures
 HTTP_CLIENT_SERVER_CONFIGURATIONS = [
-    # HTTP_CLIENT_WITH_LOCAL,
+    HTTP_CLIENT_WITH_LOCAL,
     # HTTP_CLIENT_WITH_CPU,
-    HTTP_CLIENT_WITH_GPU
+    # HTTP_CLIENT_WITH_GPU
 ]
 
 # Needed for referencing relevant pytest fixtures
 GRPC_CLIENT_SERVER_CONFIGURATIONS = [
-    # GRPC_CLIENT_WITH_LOCAL,
+    GRPC_CLIENT_WITH_LOCAL,
     # GRPC_CLIENT_WITH_CPU,
-    GRPC_CLIENT_WITH_GPU
+    # GRPC_CLIENT_WITH_GPU
 ]

--- a/tests/managers/test_model_manager.py
+++ b/tests/managers/test_model_manager.py
@@ -167,6 +167,24 @@ def test_model_handler(manager):  # noqa: F811
     noop.cleanup()
 
 
+def test_model_handler_streaming(manager):  # noqa: F811
+    spec = hub.load_spec("noop/stream-texts")
+    assert spec is not None
+
+    # NoOp: __call__
+    noop: ModelHandle = manager.load(spec)
+    assert noop is not None
+
+    idx = 0
+    result = None
+    for result in noop(texts=["hello", "world"], _stream=True):
+        assert result is not None
+        assert isinstance(result, str)
+        idx += 1
+    assert result is not None
+    assert idx > 0
+
+
 @pytest.mark.server
 def test_model_manager_custom_model_inference_with_custom_runtime(manager):  # noqa: F811
     """Test wrapping custom models for remote execution.

--- a/tests/models/test_llama2_chat.py
+++ b/tests/models/test_llama2_chat.py
@@ -1,0 +1,22 @@
+"""Llama2 Chat model tests and benchmarks."""
+import pytest
+
+from nos.models import Llama2Chat
+from nos.test.utils import skip_if_no_torch_cuda
+
+
+SYSTEM_PROMPT = "You are NOS chat, a Llama 2 large language model (LLM) agent hosted by Autonomi AI."
+
+
+@pytest.fixture(scope="module")
+def model():
+    MODEL_NAME = "HuggingFaceH4/tiny-random-LlamaForCausalLM"
+    yield Llama2Chat(model_name=MODEL_NAME)
+
+
+@skip_if_no_torch_cuda
+def test_llama2_chat(model):
+    from nos.common import tqdm
+
+    for _ in tqdm(model.chat(message="What is the meaning of life?", system_prompt=SYSTEM_PROMPT), skip=1):
+        pass

--- a/tests/models/test_noop.py
+++ b/tests/models/test_noop.py
@@ -1,11 +1,13 @@
+from nos import hub
+
+
 def test_noop():
     import numpy as np
     from PIL import Image
 
-    from nos import hub
     from nos.test.utils import NOS_TEST_IMAGE
 
-    noop = hub.load("noop/process-images")
+    noop = hub.load("noop/process")
     assert noop is not None
 
     img = Image.open(NOS_TEST_IMAGE)
@@ -28,3 +30,12 @@ def test_noop():
     outputs = noop.process_images(**inputs)
     assert outputs is not None
     assert len(outputs) == 2
+
+    inputs = {"texts": ["hello", "world"]}
+    idx = 0
+    output = None
+    for output in noop.stream_texts(**inputs):
+        assert output is not None
+        idx += 1
+    assert output is not None
+    assert idx > 0

--- a/tests/server/test_inference_service.py
+++ b/tests/server/test_inference_service.py
@@ -11,7 +11,7 @@ from PIL import Image
 
 import nos
 from nos.common import TaskType, TimingInfo, tqdm
-from nos.common.exceptions import NosInputValidationException
+from nos.common.exceptions import InputValidationException
 from nos.common.shm import NOS_SHM_ENABLED
 from nos.test.conftest import GRPC_CLIENT_SERVER_CONFIGURATIONS, ray_executor  # noqa: F401
 from nos.test.utils import NOS_TEST_IMAGE
@@ -196,7 +196,7 @@ def test_client_exception_types(client_with_server, request):
     # TODO(scott): We only validate input count and not the types themselves. When
     # we finish input validation the test should change accordingly.
     inputs = {}
-    with pytest.raises(NosInputValidationException):
+    with pytest.raises(InputValidationException):
         _ = model(**inputs)
 
 


### PR DESCRIPTION
This PR adds a new `Stream` gRPC service that allows for streaming responses from the server. This is useful for models that produce a stream of outputs such as text, video frames or audio chunks. The `Stream` service is implemented as a uni-directional output stream with a streaming response.

New models:
 - `llama2_chat` - a simple chatbot model that uses the `transformers` `AutoModelForCausalLM` with a `chat` submethod. New models include: `meta-llama/Llama-2-7b-chat-hf`, `HuggingFaceH4/zephyr-7b-beta`, `HuggingFaceH4/tiny-random-LlamaForCausalLM` (for testing purposes).

Other changes:
 - refactored names for all exceptions without `Nos` prefix

<!-- Thank you for your contribution! Please review https://github.com/autonomi-ai/nos/blob/main/docs/CONTRIBUTING.md before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Summary

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
