### PR TITLE
Support init_args, init_kwargs in model serving config.yaml

### DIFF
--- a/nos/cli/cli.py
+++ b/nos/cli/cli.py
@@ -2,9 +2,9 @@ import typer
 
 from nos.cli.hub import hub_cli
 from nos.cli.predict import predict_cli
-from nos.cli.profile import profile_cli
 from nos.cli.serve import serve_cli
 from nos.cli.system import system_cli
+from nos.logging import logger
 
 
 app_cli = typer.Typer(
@@ -16,8 +16,19 @@ app_cli = typer.Typer(
 app_cli.add_typer(hub_cli)
 app_cli.add_typer(system_cli)
 app_cli.add_typer(predict_cli)
-app_cli.add_typer(profile_cli)
 app_cli.add_typer(serve_cli)
+
+# TOFIX (spillai): Currently, the profiler requires the `torch` package
+# which shouldn't be a requirement for the CLI. We should move the profiler
+# to a separate package and import it here if it's available.
+try:
+    from nos.cli.profile import profile_cli
+
+    app_cli.add_typer(profile_cli)
+except ImportError:
+
+    logger.warning("Could not import profile_cli")
+
 
 if __name__ == "__main__":
     app_cli()

--- a/nos/cli/serve.py
+++ b/nos/cli/serve.py
@@ -300,7 +300,7 @@ def _serve(
         # Copy the dockerfiles to the current working directory if debug is enabled.
         for _docker_target, filename in dockerfiles.items():
             if debug:
-                shutil.copyfile(filename, Path.cwd() / filename.name)
+                shutil.copyfile(filename, Path.cwd() / filename)
 
         # Check if the image was built
         if image_name is None:

--- a/nos/common/spec.py
+++ b/nos/common/spec.py
@@ -183,6 +183,20 @@ class FunctionSignature:
         """Return the function signature representation."""
         return f"FunctionSignature({asdict(self)})"
 
+    @validator("init_args", pre=True)
+    def _validate_init_args(cls, init_args: Union[Tuple[Any, ...], Any]) -> Tuple[Any, ...]:
+        """Validate the initialization arguments."""
+        # TODO (spillai): Check the function signature of the func_or_cls class and validate
+        # the init_args against the signature.
+        return init_args
+
+    @validator("init_kwargs", pre=True)
+    def _validate_init_kwargs(cls, init_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """Validate the initialization keyword arguments."""
+        # TODO (spillai): Check the function signature of the func_or_cls class and validate
+        # the init_kwargs against the signature.
+        return init_kwargs
+
     @staticmethod
     def validate(inputs: Dict[str, Any], sig: Dict[str, Any]) -> Dict[str, Any]:
         """Validate the input dict against the defined signature (input or output)."""

--- a/nos/hub/__init__.py
+++ b/nos/hub/__init__.py
@@ -173,7 +173,9 @@ class Hub:
 
         @dataclass
         class _ModelImportConfig:
-            """Model import configuration."""
+            """Model import configuration.
+            Main entrypoint for defining new "models" in the serve.yaml.
+            """
 
             id: str
             """Model identifier."""
@@ -185,6 +187,8 @@ class Hub:
             """Default model method name."""
             runtime_env: str
             """Runtime environment."""
+            init_kwargs: Dict[str, Any] = field(default_factory=dict)
+            """Model class init keyword arguments."""
 
             @root_validator(pre=True, allow_reuse=True)
             def _validate_model_cls_import(cls, values):
@@ -262,6 +266,8 @@ class Hub:
                 TaskType.CUSTOM,
                 mconfig.model_cls,
                 method=mconfig.default_method,
+                init_args=(),
+                init_kwargs=mconfig.init_kwargs,
             )
             logger.debug(f"Registered model [id={model_id}, spec={spec}]")
             specs.append(spec)

--- a/nos/models/llama2_chat.py
+++ b/nos/models/llama2_chat.py
@@ -65,10 +65,6 @@ class Llama2Chat:
             model_name="HuggingFaceH4/zephyr-7b-beta",
             compute_dtype="float16",
         ),
-        "ehartford/dolphin-2.1-mistral-7b": Llama2ChatConfig(
-            model_name="ehartford/dolphin-2.1-mistral-7b",
-            compute_dtype="float16",
-        ),
         "HuggingFaceH4/tiny-random-LlamaForCausalLM": Llama2ChatConfig(
             model_name="HuggingFaceH4/tiny-random-LlamaForCausalLM",
             compute_dtype="float16",

--- a/nos/models/llama2_chat.py
+++ b/nos/models/llama2_chat.py
@@ -65,6 +65,10 @@ class Llama2Chat:
             model_name="HuggingFaceH4/zephyr-7b-beta",
             compute_dtype="float16",
         ),
+        "ehartford/dolphin-2.1-mistral-7b": Llama2ChatConfig(
+            model_name="ehartford/dolphin-2.1-mistral-7b",
+            compute_dtype="float16",
+        ),
         "HuggingFaceH4/tiny-random-LlamaForCausalLM": Llama2ChatConfig(
             model_name="HuggingFaceH4/tiny-random-LlamaForCausalLM",
             compute_dtype="float16",

--- a/nos/test/test_data/hub/custom_model/config-alternate-init-kwargs.yaml
+++ b/nos/test/test_data/hub/custom_model/config-alternate-init-kwargs.yaml
@@ -1,14 +1,7 @@
-images:
-  gpu:
-    base: autonomi/nos:latest-gpu
-    workdir: /app/serve
-
 models:
   custom-model:
     model_path: models/model.py
     model_cls: CustomModel
-    init_kwargs:
-      kwarg_int: 2
-      kwarg_str: "3"
+    init_kwargs: {"kwarg_int": 2, "kwarg_str": "3"}
     default_method: __call__
     runtime_env: gpu

--- a/nos/test/test_data/hub/custom_model/models/model.py
+++ b/nos/test/test_data/hub/custom_model/models/model.py
@@ -1,5 +1,5 @@
 class CustomModel:
-    def __init__(self):
+    def __init__(self, arg1: str, kwarg_int: int = 1, kwarg_str: str = "2"):
         pass
 
     def __call__(self, prompts: str) -> str:

--- a/requirements/requirements.server.txt
+++ b/requirements/requirements.server.txt
@@ -3,6 +3,7 @@ huggingface_hub>=0.17.3
 pyarrow>=12.0.0
 ray[default]==2.7.0
 safetensors>=0.3.0
+sentencepiece
 tabulate
 timm>=0.9.2
 transformers>=4.35.0

--- a/requirements/requirements.server.txt
+++ b/requirements/requirements.server.txt
@@ -3,7 +3,6 @@ huggingface_hub>=0.17.3
 pyarrow>=12.0.0
 ray[default]==2.7.0
 safetensors>=0.3.0
-sentencepiece
 tabulate
 timm>=0.9.2
 transformers>=4.35.0

--- a/tests/hub/test_hub.py
+++ b/tests/hub/test_hub.py
@@ -100,6 +100,7 @@ def test_hub_register_from_yaml():
     # Test valid model configs
     for yaml in [
         NOS_TEST_DATA_DIR / "hub/custom_model/config.yaml",
+        NOS_TEST_DATA_DIR / "hub/custom_model/config-alternate-init-kwargs.yaml",
     ]:
         Hub.register_from_yaml(yaml)
 
@@ -117,13 +118,8 @@ def test_hub_register_from_yaml():
     ]:
 
         with pytest.raises(Exception):
-            try:
-                Hub.register_from_yaml(yaml)
-            except Exception as exc:
-                logger.debug(
-                    f"Successfully raised exception when loading model spec from malformed YAML: {yaml}, e={exc}"
-                )
-                raise exc
+            logger.debug(f"Loading model spec from malformed YAML: {yaml}")
+            Hub.register_from_yaml(yaml)
 
     logger.enable("nos")
 


### PR DESCRIPTION
## Summary

This PR adds support for `init_args` and `init_kwargs` in `config.yaml`
 for model serving. This allows users to pass arguments to the
  `__init__` method of the model class and define new model-ids with
  different configurations.

This PR also hotfixes a few other issues in the serve CLI
 - `nos.profile` import fails gracefully with client-side (i.e. without torch dependency)

## Related issues

Resolves #474 

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
