### PR TITLE
Custom model scaling support for deployments.

### DIFF
--- a/nos/cli/templates/docker-compose.serve.yml.j2
+++ b/nos/cli/templates/docker-compose.serve.yml.j2
@@ -32,12 +32,12 @@ services:
 {% endif %}
   nos-server:
     image: {{ image }}
+    {%- if config %}
+    command: nos-grpc-server -c {{ config }}
+    {%- endif %}
     environment:
       - NOS_HOME=/app/.nos
       - NOS_LOGGING_LEVEL={{ logging_level }}
-      {%- if config %}
-      - NOS_HUB_CATALOG_PATH=$NOS_HUB_CATALOG_PATH:{{ config }}
-      {%- endif %}
     {%- if env_file|length > 0 %}
     env_file:
       {%- for envf in env_file %}

--- a/nos/common/__init__.py
+++ b/nos/common/__init__.py
@@ -10,6 +10,7 @@ from .runtime import RuntimeEnv
 from .shm import SharedMemoryDataDict, SharedMemoryNumpyObject, SharedMemoryTransportManager  # noqa: F401
 from .spec import (
     FunctionSignature,
+    ModelDeploymentSpec,
     ModelResources,
     ModelSpec,
     ModelSpecMetadata,

--- a/nos/common/spec.py
+++ b/nos/common/spec.py
@@ -730,3 +730,13 @@ class ModelSpec:
     def _from_proto(minfo: nos_service_pb2.GenericResponse) -> "ModelSpec":
         """Convert the generic response back to the spec."""
         return loads(minfo.response_bytes)
+
+
+@dataclass
+class ModelDeploymentSpec:
+    """Model deployment specification."""
+
+    num_replicas: int = 1
+    """Number of replicas."""
+    resources: ModelResources = field(default_factory=ModelResources)
+    """Model resources."""

--- a/nos/test/test_data/hub/custom_model/config-with-replicas.yaml
+++ b/nos/test/test_data/hub/custom_model/config-with-replicas.yaml
@@ -1,0 +1,32 @@
+images:
+  gpu:
+    base: autonomi/nos:latest-gpu
+    workdir: /app/serve
+
+models:
+  custom/custom-model-a:
+    runtime_env: gpu
+    model_cls: CustomModel
+    model_path: models/model.py
+    default_method: __call__
+    init_args:
+      - "arg-a"
+    deployment:
+      resources:
+        device: auto
+        device_memory: 1Gi
+      num_replicas: 2
+
+  custom/custom-model-b:
+    runtime_env: gpu
+    model_cls: CustomModel
+    model_path: models/model.py
+    default_method: __call__
+    init_args:
+      - "arg-b"
+    deployment:
+      resources:
+        cpu: 2
+        memory: 2Gi
+        device: cpu
+      num_replicas: 2

--- a/tests/hub/test_hub.py
+++ b/tests/hub/test_hub.py
@@ -85,7 +85,15 @@ def test_hub_catalog():
 
     pvalue = os.getenv("NOS_HUB_CATALOG_PATH", "")
     nmodels = len(Hub.list())
-    os.environ["NOS_HUB_CATALOG_PATH"] = str(NOS_TEST_DATA_DIR / "hub/custom_model/config.yaml")
+    os.environ["NOS_HUB_CATALOG_PATH"] = ":".join(
+        [
+            str(yaml)
+            for yaml in [
+                NOS_TEST_DATA_DIR / "hub/custom_model/config.yaml",
+                NOS_TEST_DATA_DIR / "hub/custom_model/config-with-replicas.yaml",
+            ]
+        ]
+    )
     Hub.register_from_catalog()
     os.environ["NOS_HUB_CATALOG_PATH"] = pvalue
     assert (


### PR DESCRIPTION
## Summary

This PR allows users to customize their model deployments
with model-level resources and replicas. The new deployment
strategy uses a custom model config that can be passed to the
inference server via `nos-grpc-server -c <config>.yaml` as
opposed to the previous approach of setting a catalog environment
variable.

New features:
 - custom models are now loaded and replicated on init
 - model resources can be individually set for models, and
 their GPU resources are automatically determined and allocated
 - new `deployment` section in the model config allows users to
 set model-level `resources` and `num_replicas` (see YAML below).

New deployment YAML spec for custom models can now include:

```yaml
images:
  custom-gpu:
    base: autonomi/nos:latest-gpu
    pip:
      - accelerate>=0.23.0
      - transformers>=4.35.1

models:
  custom/custom-model-a:
    runtime_env: custom-gpu
    model_cls: CustomModel
    model_path: models/model.py
    default_method: __call__
    init_kwargs:
      model_name: custom/custom-model-a
    deployment:
      resources:
        device: auto
        device_memory: 4Gi
      num_replicas: 2

  custom/custom-model-b:
    runtime_env: custom-gpu
    model_cls: CustomModel
    model_path: models/model.py
    default_method: __call__
    init_kwargs:
      model_name: custom/custom-model-b
    deployment:
      resources:
        cpu: 2
        memory: 2Gi
        device: cpu
      num_replicas: 2
```


## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
