### PR TITLE
Various dev-ex improvements (runtime, logging etc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,10 @@ model_id: str = "mv-dream"
 
 This project is licensed under the [Apache-2.0 License](LICENSE).
 
+## 📡 Telemetry
+
+NOS collects anonymous usage data using [Sentry](https://sentry.io/). This is used to help us understand how the community is using NOS and to help us prioritize features. You can opt-out of telemetry by setting `NOS_TELEMETRY_ENABLED=0`.
+
 ## 🤝 Contributing
 We welcome contributions! Please see our [contributing guide](CONTRIBUTING.md) for more information.
 

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -62,7 +62,6 @@ RUN --mount=type=cache,target=${CONDA_PKGS_DIRS}  \
     torchvision \
     pytorch-cuda=11.8 \
     cudatoolkit=11.8 \
-    cudnn=8.2.1 \
     -c pytorch -c nvidia \
     && echo "conda/mamba install complete"
 

--- a/docker/agibuild.gpu.yaml
+++ b/docker/agibuild.gpu.yaml
@@ -16,7 +16,6 @@ images:
       - torchvision
       - pytorch-cuda=11.8
       - cudatoolkit=11.8
-      - cudnn=8.2.1
       - -c pytorch -c nvidia
     requirements:
       - requirements/requirements.txt

--- a/nos/client/grpc.py
+++ b/nos/client/grpc.py
@@ -161,7 +161,9 @@ class Client:
             try:
                 return self.IsHealthy()
             except Exception:
-                logger.warning("Waiting for server to start... (elapsed={:.0f}s)".format(time.time() - st))
+                elapsed = time.time() - st
+                if int(elapsed) > 10:
+                    logger.warning("Waiting for server to start... (elapsed={:.0f}s)".format(time.time() - st))
                 time.sleep(retry_interval)
         raise ServerReadyException("Failed to ping server.")
 

--- a/nos/exceptions.py
+++ b/nos/exceptions.py
@@ -1,9 +1,11 @@
 """Custom exceptions for the nos package."""
 from dataclasses import dataclass
 
+from nos.logging import logger
 
-@dataclass(frozen=True)
-class NosServerException(Exception):
+
+@dataclass
+class ServerException(Exception):
     """Base exception for the nos client."""
 
     message: str
@@ -11,12 +13,18 @@ class NosServerException(Exception):
     exc: Exception = None
     """Exception object."""
 
+    def __post_init__(self) -> None:
+        if self.exc is not None:
+            self.message = f"{self.message}, details={self.exc}"
+        logger.error(self.message)
+
     def __str__(self) -> str:
         return f"{self.message}"
 
 
-class ModelNotFoundError(NosServerException):
+class ModelNotFoundError(ServerException):
     """Exception raised when the model is not found."""
 
-    def __str__(self) -> str:
-        return f"Model not found, details={self.message}"
+
+class OutOfDeviceMemoryError(ServerException):
+    """Exception raised when the device is out of memory."""

--- a/nos/executors/ray.py
+++ b/nos/executors/ray.py
@@ -31,6 +31,7 @@ from nos.logging import LOGGING_LEVEL
 
 
 logger = logging.getLogger(__name__)
+logging.getLogger("ray").setLevel(logging.ERROR)
 
 
 @dataclass
@@ -96,6 +97,7 @@ class RayExecutor(metaclass=SingletonMetaclass):
                         address="auto",
                         namespace=self.spec.namespace,
                         ignore_reinit_error=True,
+                        logging_level="error",
                     )
                     status.stop()
                     console.print("[bold green] ✓ InferenceExecutor :: Connected to backend. [/bold green]")

--- a/nos/managers/model.py
+++ b/nos/managers/model.py
@@ -20,7 +20,7 @@ from nos.logging import logger
 from nos.managers.pool import ActorPool
 
 
-NOS_MAX_CONCURRENT_MODELS = int(os.getenv("NOS_MAX_CONCURRENT_MODELS", 4))
+NOS_MAX_CONCURRENT_MODELS = int(os.getenv("NOS_MAX_CONCURRENT_MODELS", 1))
 NOS_MEMRAY_ENABLED = bool(int(os.getenv("NOS_MEMRAY_ENABLED", 0)))
 NOS_RAY_LOGS_DIR = os.getenv("NOS_RAY_LOGS_DIR", "/tmp/ray/session_latest/logs")
 

--- a/nos/managers/model.py
+++ b/nos/managers/model.py
@@ -20,7 +20,7 @@ from nos.logging import logger
 from nos.managers.pool import ActorPool
 
 
-NOS_MAX_CONCURRENT_MODELS = int(os.getenv("NOS_MAX_CONCURRENT_MODELS", 2))
+NOS_MAX_CONCURRENT_MODELS = int(os.getenv("NOS_MAX_CONCURRENT_MODELS", 4))
 NOS_MEMRAY_ENABLED = bool(int(os.getenv("NOS_MEMRAY_ENABLED", 0)))
 NOS_RAY_LOGS_DIR = os.getenv("NOS_RAY_LOGS_DIR", "/tmp/ray/session_latest/logs")
 

--- a/nos/models/llama2_chat.py
+++ b/nos/models/llama2_chat.py
@@ -74,6 +74,10 @@ class Llama2Chat:
             compute_dtype="float16",
             additional_kwargs={"use_flashattention_2": True, "trust_remote_code": True},
         ),
+        "mistralai/Mistral-7B-Instruct-v0.2": Llama2ChatConfig(
+            model_name="mistralai/Mistral-7B-Instruct-v0.2",
+            compute_dtype="float16",
+        ),
     }
 
     def __init__(self, model_name: str = "HuggingFaceH4/zephyr-7b-beta"):

--- a/nos/models/llama2_chat.py
+++ b/nos/models/llama2_chat.py
@@ -118,7 +118,7 @@ class Llama2Chat:
         num_beams: int = 1,
     ) -> Iterable[str]:
         """Chat with the model."""
-        self.logger.info(f"Conversation: {messages}")
+        self.logger.debug(f"Conversation: {messages}")
         input_ids = self.tokenizer.apply_chat_template(
             messages, chat_template=self.cfg.chat_template, return_tensors="pt"
         )

--- a/nos/protoc.py
+++ b/nos/protoc.py
@@ -4,8 +4,9 @@ import time
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import List
+from typing import ClassVar, List
 
+from filelock import FileLock
 from grpc_tools import protoc
 
 from nos.constants import NOS_CACHE_DIR, NOS_PATH
@@ -20,7 +21,7 @@ logger.disable(__name__)
 class DynamicProtobufCompiler:
     _instance = None
     """Singleton instance."""
-    cache_dir = NOS_CACHE_DIR / "protobuf"
+    cache_dir: ClassVar[str] = NOS_CACHE_DIR / "protobuf"
     """Cache directory for compiled protobuf modules."""
 
     def __init__(self) -> None:
@@ -83,5 +84,6 @@ class DynamicProtobufCompiler:
 @lru_cache(maxsize=None)
 def import_module(module_name: str):
     """Import the specified module and return the imported module object."""
-    compiler = DynamicProtobufCompiler.get()
-    return compiler.import_module(module_name)
+    with FileLock(str(Path(str(DynamicProtobufCompiler.cache_dir)) / "protoc.lock")):
+        compiler = DynamicProtobufCompiler.get()
+        return compiler.import_module(module_name)

--- a/nos/protoc.py
+++ b/nos/protoc.py
@@ -13,6 +13,7 @@ from nos.logging import logger
 
 
 PROTO_PATHS = [NOS_PATH / "proto"]
+logger.disable(__name__)
 
 
 @dataclass

--- a/nos/server/http/_service.py
+++ b/nos/server/http/_service.py
@@ -84,7 +84,10 @@ class InferenceService:
         self.client = Client(self.address)
         logger.debug(f"Connecting to gRPC server (address={self.client.address})")
 
-        self.client.WaitForServer(timeout=60)
+        if not self.client.WaitForServer(timeout=60, retry_interval=5):
+            raise RuntimeError("Failed to connect to gRPC server")
+        if not self.client.IsHealthy():
+            raise RuntimeError("gRPC server is not healthy")
         runtime = self.client.GetServiceRuntime()
         version = self.client.GetServiceVersion()
         logger.debug(f"Connected to gRPC server (address={self.client.address}, runtime={runtime}, version={version})")
@@ -166,9 +169,12 @@ def app_factory(
         models: List[str] = client.ListModels()
         for model_id in models:
             spec = client.GetModelInfo(model_id)
-            if spec.task() != TaskType.TEXT_GENERATION:
+            if not (spec.task() == TaskType.TEXT_GENERATION or spec.task() == TaskType.CUSTOM):
                 continue
-            owned_by, _ = model_id.split("/")
+            try:
+                owned_by, _ = model_id.split("/")
+            except ValueError:
+                owned_by = "unknown-org"
             _model_table[normalize_id(model_id)] = ChatModel(id=normalize_id(model_id), created=0, owned_by=owned_by)
             logger.debug(f"Registered model [model={model_id}, m={_model_table[normalize_id(model_id)]}, spec={spec}]")
         return _model_table
@@ -463,8 +469,7 @@ def main():
 
     import uvicorn
 
-    from nos.client import Client
-    from nos.constants import DEFAULT_GRPC_PORT, DEFAULT_HTTP_PORT
+    from nos.constants import DEFAULT_HTTP_PORT
     from nos.logging import logger
 
     parser = argparse.ArgumentParser(description="NOS REST API Service")
@@ -483,15 +488,6 @@ def main():
     parser.add_argument("--log-level", type=str, default="info", help="Logging level")
     args = parser.parse_args()
     logger.debug(f"args={args}")
-
-    # Wait for the gRPC server to be ready
-    logger.debug(f"Initializing gRPC client (port={DEFAULT_GRPC_PORT})")
-    client = Client(f"[::]:{DEFAULT_GRPC_PORT}")
-    logger.debug(f"Initialized gRPC client, connecting to gRPC server (address={client.address})")
-    if not client.WaitForServer(timeout=180, retry_interval=5):
-        raise RuntimeError("Failed to connect to gRPC server")
-    if not client.IsHealthy():
-        raise RuntimeError("gRPC server is not healthy")
 
     # Start the NOS REST API service
     logger.debug(

--- a/nos/server/http/_service.py
+++ b/nos/server/http/_service.py
@@ -170,6 +170,7 @@ def app_factory(
                 continue
             owned_by, _ = model_id.split("/")
             _model_table[normalize_id(model_id)] = ChatModel(id=normalize_id(model_id), created=0, owned_by=owned_by)
+            logger.debug(f"Registered model [model={model_id}, m={_model_table[normalize_id(model_id)]}, spec={spec}]")
         return _model_table
 
     @app.get("/")
@@ -222,15 +223,8 @@ def app_factory(
         if len(request.messages) > 0 and request.messages[-1].role != "user":
             raise HTTPException(status_code=400, detail="Invalid chat request, last message must be from the user")
 
-        messages = [message.dict() for message in request.messages]
-        if len(request.messages) > 1 and request.messages[0].role == "system":
-            system_prompt = request.messages[0].content
-        else:
-            system_prompt = "You are NOS chat, a Llama 2 large language model (LLM) agent hosted by Autonomi AI."
-            messages.insert(0, {"role": "system", "content": system_prompt})
-        logger.debug(f"Chat [model={request.model}, message={messages}, system_prompt={system_prompt}]")
-
         # Perform chat completion (streaming)
+        messages = [message.dict() for message in request.messages]
         if request.stream:
 
             def openai_streaming_generator():

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,7 @@
 agi-pack>=0.1.19
 cloudpickle>=2.2.1
 docker>=6.0.0
+filelock
 gitpython
 grpcio-tools<=1.49.1
 humanize

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -4,7 +4,11 @@
 NCORES=$(nproc --all)
 echo "Starting server with OMP_NUM_THREADS=${OMP_NUM_THREADS:-${NCORES}}..."
 # Get OMP_NUM_THREADS from environment variable, if set otherwise use 1
-OMP_NUM_THREADS=${OMP_NUM_THREADS:-${NCORES}} ray start --head
-
-echo "Starting NOS server..."
+OMP_NUM_THREADS=${OMP_NUM_THREADS:-${NCORES}} \
+ray --logging-level warning \
+    start --head \
+    --port 6379 \
+    --disable-usage-stats \
+    --include-dashboard 0 \
+    > /tmp/ray_server.log
 nos-grpc-server

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,25 @@
+from nos import exceptions as exc
+
+
+def test_server_exception():
+    message = "Test ServerException"
+    exception = ValueError("Test Exception")
+    server_exception = exc.ServerException(message, exception)
+
+    assert server_exception.message.startswith(message)
+    assert server_exception.exc == exception
+
+    expected_error_message = f"{message}, details={exception}"
+    assert str(server_exception) == expected_error_message
+
+
+def test_model_not_found_error():
+    message = "Test ModelNotFoundError"
+    exception = ValueError("Test Exception")
+    model_not_found_error = exc.ModelNotFoundError(message, exception)
+
+    assert model_not_found_error.message.startswith(message)
+    assert model_not_found_error.exc == exception
+
+    expected_error_message = f"{message}, details={exception}"
+    assert str(model_not_found_error) == expected_error_message


### PR DESCRIPTION
## Summary
- Removed redundant `cudnn` dependencies (since Pytorch already ships cudnn so's in `$CONDA_PREFIX/python3.8/site-packages/torch/lib`
- Removed system prompts from defaults to allow users more flexibility
- Added `mistralai/Mistral-7B-Instruct-v0.2` to llama chat
- Several log cleanup on startup for prettier demos
- Disabled ray usage stats and dashboard for now

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
