### PR TITLE
[tutorial] Add streaming chat tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ from nos.client import Client
 client = Client("[::]:50051")
 
 model = client.Module("meta-llama/Llama-2-7b-chat-hf")
-response = model.chat(message="Tell me a story of 1000 words with emojis")
+response = model.chat(message="Tell me a story of 1000 words with emojis", _stream=True)
 ```
 
 </td>
@@ -261,6 +261,7 @@ Want to run models not supported by NOS? You can easily add your own models foll
 
 ## 📚 Documentation
 
+- [Tutorials](./examples/tutorials/)
 - [Quickstart](https://docs.nos.run/docs/quickstart.html)
 - [Models](https://docs.nos.run/docs/models/supported-models.html)
 - **Concepts**: [Architecture Overview](https://docs.nos.run/docs/concepts/architecture-overview.html), [ModelSpec](https://docs.nos.run/docs/concepts/model-spec.html), [ModelManager](https://docs.nos.run/docs/concepts/model-manager.html), [Runtime Environments](https://docs.nos.run/docs/concepts/runtime-environments.html)

--- a/examples/tutorials/03-llm-streaming-chat/models/chat.py
+++ b/examples/tutorials/03-llm-streaming-chat/models/chat.py
@@ -1,0 +1,118 @@
+import time
+from dataclasses import dataclass
+from threading import Thread
+from typing import Any, Dict, Iterable, List
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, TextIteratorStreamer
+
+from nos.hub import HuggingFaceHubConfig, hf_login
+
+
+@dataclass(frozen=True)
+class StreamingChatConfig(HuggingFaceHubConfig):
+    """Streaming chat model configuration."""
+
+    max_new_tokens: int = 2048
+    """Maximum number of tokens to generate."""
+
+    max_input_token_length: int = 4096
+    """Maximum number of tokens in the input."""
+
+    compute_dtype: str = "float16"
+    """Compute type for the model."""
+
+    needs_auth: bool = False
+    """Whether the model needs authentication."""
+
+    additional_kwargs: Dict[str, Any] = None
+    """Additional keyword arguments to pass to the model."""
+
+    chat_template: str = None
+    """Chat template to use for the model."""
+
+
+class StreamingChat:
+    configs = {
+        "TinyLlama/TinyLlama-1.1B-Chat-v1.0": StreamingChatConfig(
+            model_name="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+            compute_dtype="bfloat16",
+        ),
+    }
+
+    def __init__(self, model_name: str = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"):
+        from nos.logging import logger
+
+        try:
+            self.cfg = StreamingChat.configs[model_name]
+        except KeyError:
+            raise ValueError(
+                f"Invalid model_name: {model_name}, available models: {StreamingChatConfig.configs.keys()}"
+            )
+
+        self.device_str = "cuda" if torch.cuda.is_available() else "cpu"
+        self.device = torch.device(self.device_str)
+
+        token = hf_login() if self.cfg.needs_auth else None
+        self.model = AutoModelForCausalLM.from_pretrained(
+            self.cfg.model_name,
+            torch_dtype=getattr(torch, self.cfg.compute_dtype),
+            token=token,
+            device_map="auto",
+            **(self.cfg.additional_kwargs or {}),
+        )
+        self.tokenizer = AutoTokenizer.from_pretrained(self.cfg.model_name, token=token)
+        self.tokenizer.use_default_system_prompt = False
+        self.logger = logger
+
+    @torch.inference_mode()
+    def chat(
+        self,
+        messages: List[Dict[str, str]],
+        max_new_tokens: int = 1024,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        top_k: int = 50,
+        repetition_penalty: float = 1.2,
+        num_beams: int = 1,
+    ) -> Iterable[str]:
+        """Chat with the model."""
+        self.logger.debug(f"Conversation: {messages}")
+        input_ids = self.tokenizer.apply_chat_template(
+            messages, chat_template=self.cfg.chat_template, return_tensors="pt"
+        )
+        if input_ids.shape[1] > self.cfg.max_input_token_length:
+            input_ids = input_ids[:, -self.cfg.max_input_token_length :]
+            self.logger.warning(
+                f"Trimmed input from conversation as it was longer than {self.cfg.max_input_token_length} tokens."
+            )
+        input_ids = input_ids.to(self.model.device)
+
+        streamer = TextIteratorStreamer(self.tokenizer, timeout=180.0, skip_prompt=True, skip_special_tokens=True)
+        generate_kwargs = dict(
+            {"input_ids": input_ids},
+            streamer=streamer,
+            max_new_tokens=max_new_tokens,
+            do_sample=True,
+            top_p=top_p,
+            top_k=top_k,
+            temperature=temperature,
+            num_beams=num_beams,
+            repetition_penalty=repetition_penalty,
+        )
+        t = Thread(target=self.model.generate, kwargs=generate_kwargs)
+        t.start()
+
+        start_t = None
+        for idx, text in enumerate(streamer):
+            yield text
+            # We only measure the time after the first token is generated
+            if start_t is None:
+                start_t = time.perf_counter()
+            if idx > 0:
+                self.logger.debug(
+                    f"""tok/s={idx / (time.perf_counter() - start_t):.2f}, """
+                    f"""memory={torch.cuda.memory_allocated(device=self.model.device) / 1024 ** 2:.2f} MB, """
+                    f"""allocated={torch.cuda.max_memory_allocated(device=self.model.device) / 1024 ** 2:.2f} MB, """
+                    f"""peak={torch.cuda.max_memory_reserved(device=self.model.device) / 1024 ** 2:.2f} MB, """
+                )

--- a/examples/tutorials/03-llm-streaming-chat/serve.yaml
+++ b/examples/tutorials/03-llm-streaming-chat/serve.yaml
@@ -1,0 +1,16 @@
+images:
+  llm-gpu:
+    base: autonomi/nos:latest-gpu
+
+models:
+  TinyLlama/TinyLlama-1.1B-Chat-v1.0:
+    model_cls: StreamingChat
+    model_path: models/chat.py
+    init_kwargs:
+      model_name: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+    default_method: chat
+    runtime_env: llm-gpu
+    deployment:
+      resources:
+        device: auto
+        device_memory: 3Gi

--- a/examples/tutorials/03-llm-streaming-chat/tests/test_chat.py
+++ b/examples/tutorials/03-llm-streaming-chat/tests/test_chat.py
@@ -1,0 +1,149 @@
+import sys
+
+import pytest
+from rich import print
+
+from nos.client import Client
+
+
+HTTP_PORT = 8000
+GRPC_PORT = 50051
+MODELS = [
+    "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def client():
+    client = Client(f"[::]:{GRPC_PORT}")
+    assert client.WaitForServer()
+    yield client
+
+
+@pytest.mark.parametrize("model_id", MODELS)
+def test_streaming_chat_grpc(client, model_id):
+
+    # Load the llama chat model
+    model = client.Module(model_id)
+
+    # Chat with the model
+    query = "What is the meaning of life?"
+
+    print()
+    print("-" * 80)
+    print(f">>> Chatting with the model (model={model_id}) ...")
+    print(f"[bold yellow]Query: {query}[/bold yellow]")
+    messages = [
+        {"role": "system", "content": ""},
+        {"role": "user", "content": query},
+    ]
+    for response in model.chat(messages=messages, max_new_tokens=1024, _stream=True):
+        sys.stdout.write(response)
+        sys.stdout.flush()
+    print()
+
+
+@pytest.mark.parametrize("model_id", MODELS)
+def test_streaming_chat_http(model_id):
+    import requests
+
+    BASE_URL = f"http://localhost:{HTTP_PORT}"
+
+    # model_id for LLMs are normalized replacing "/" with "--"
+    model_id = model_id.replace("/", "--")
+
+    http_client = requests.Session()
+    response = http_client.get(
+        f"{BASE_URL}/v1/models",
+        headers={"accept": "application/json"},
+    )
+    assert response.status_code == 200
+    assert isinstance(response.json(), dict)
+    models = response.json()["data"]
+    for model in models:
+        assert "id" in model
+        assert "object" in model
+        response = http_client.get(
+            f"{BASE_URL}/v1/models/{model['id']}",
+            headers={"accept": "application/json"},
+        )
+        assert response.status_code == 200, "Failed to get model info: {}".format(model["id"])
+
+    with http_client.post(
+        f"{BASE_URL}/v1/chat/completions",
+        headers={"accept": "application/json"},
+        json={
+            "model": model_id,
+            "messages": [
+                {"role": "system", "content": "You are a helpful AI assistant."},
+                {"role": "user", "content": "What is the meaning of life?"},
+            ],
+            "max_tokens": 512,
+            "temperature": 0.7,
+            "stream": True,
+        },
+        stream=True,
+    ) as response:
+        for chunk in response.iter_content():
+            sys.stdout.write(chunk.decode("utf-8"))
+            sys.stdout.flush()
+
+
+@pytest.mark.skip(reason="Not implemented")
+@pytest.mark.parametrize("model_id", MODELS)
+def test_streaming_chat_openai(model_id):
+    import time
+
+    import openai
+    import requests
+
+    # model_id for LLMs are normalized replacing "/" with "--"
+    model_id = model_id.replace("/", "--")
+
+    # Check health
+    BASE_URL = f"http://localhost:{HTTP_PORT}/v1"
+    response = requests.get(f"{BASE_URL}/health")
+    assert response.status_code == 200
+
+    client = openai.OpenAI(base_url=BASE_URL, api_key="sk-fake-key")
+    assert client is not None
+
+    # List all models
+    models = client.models.list()
+    assert models is not None
+    print(models)
+
+    # Create a chat completion prompt
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Tell a story in less than 300 words."},
+        {"role": "user", "content": "Make it funny."},
+    ]
+
+    # Test chat completion (non-streaming)
+    st = time.time()
+    chat_completion = client.chat.completions.create(
+        model=model_id,
+        messages=messages,
+        temperature=0.7,
+    )
+    print(f"chat completion took {(time.time() - st):.3f} seconds to complete")
+    assert chat_completion is not None
+    assert isinstance(chat_completion, openai.types.chat.chat_completion.ChatCompletion)
+
+    # Test chat completion (streaming)
+    st = time.time()
+    for chunk in client.chat.completions.create(
+        model=model_id,
+        messages=messages,
+        temperature=0.7,
+        stream=True,
+    ):
+        if st is not None:
+            print(f"chat completion took {time.time() - st:.3f} seconds to start streaming")
+            st = None
+        assert chunk is not None
+        assert isinstance(chunk, openai.types.chat.chat_completion_chunk.ChatCompletionChunk)
+        assert chunk.choices is not None
+        assert isinstance(chunk.choices, list)
+        assert isinstance(chunk.choices[0].delta, openai.types.chat.chat_completion_chunk.ChoiceDelta)

--- a/examples/tutorials/README.md
+++ b/examples/tutorials/README.md
@@ -1,0 +1,28 @@
+## 📦 NOS Tutorials
+
+The following tutorials give a brief overview of how to use NOS to serve models.
+
+- [x] [`01-serving-custom-models`](./01-serving-custom-models): Serve a custom GPU model with NOS.
+- [x] [`02-serving-custom-methods`](./02-serving-custom-methods): Expose several custom methods of a model for serving purposes.
+- [x] [`03-llm-streaming-chat`](./03-llm-streaming-chat): Serve an LLM with *streaming* support ([`TinyLlama/TinyLlama-1.1B-Chat-v0.1`](https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v0.1)).
+
+
+## 🏃‍♂️ Running the examples
+
+For each of the examples, you can run the following command to serve the model (in one of your terminals):
+
+```bash
+nos serve up -c serve.yaml
+```
+
+You can then run the tests in the `tests` directory to check if the model is served correctly:
+
+```bash
+pytest -sv ./tests
+```
+
+For HTTP tests, you'll need add the `--http` flag to the `nos serve` command:
+
+```bash
+nos serve up -c serve.yaml --http
+```


### PR DESCRIPTION
## Summary

 - based on `TinyLlama/TinyLlama-1.1B-Chat-v1.0` model
 - adds tests for both gRPC and HTTP clients

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
