### PR TITLE
Remove `py311-cu118` and `py38-cu121`

### DIFF
--- a/makefiles/Makefile.agibuild.mk
+++ b/makefiles/Makefile.agibuild.mk
@@ -61,18 +61,6 @@ agi-build-py310-cu118:
 		${DOCKER_IMAGE_NAME}:${NOS_VERSION_TAG}-py310-cu118 \
 		${DOCKER_IMAGE_NAME}:latest-py310-cu118
 
-agi-build-py311-cu118:
-	agi-pack build ${AGIPACK_ARGS} \
-		--target gpu \
-		-c docker/agibuild.gpu.yaml \
-		-o docker/Dockerfile.py310-cu118 \
-		-p 3.11.4 \
-		-b nvidia/cuda:11.8.0-base-ubuntu22.04 \
-		-t '${DOCKER_IMAGE_NAME}:${NOS_VERSION_TAG}-{target}-py311-cu118'
-	docker tag \
-		${DOCKER_IMAGE_NAME}:${NOS_VERSION_TAG}-py311-cu118 \
-		${DOCKER_IMAGE_NAME}:latest-py311-cu118
-
 agi-build-py38-cu121:
 	agi-pack build ${AGIPACK_ARGS} \
 		--target gpu \
@@ -100,11 +88,9 @@ agi-build-py310-cu121:
 agi-build-cu118: \
 	agi-build-py38-cu118 \
 	agi-build-py39-cu118 \
-	agi-build-py310-cu118 \
-	agi-build-py311-cu118
+	agi-build-py310-cu118
 
 agi-build-cu121: \
-	agi-build-py38-cu121 \
 	agi-build-py310-cu121
 
 agi-push-cu118:
@@ -114,11 +100,7 @@ agi-push-cu118:
 	docker push ${DOCKER_IMAGE_NAME}:latest-py39-cu118
 	docker push ${DOCKER_IMAGE_NAME}:${NOS_VERSION_TAG}-py310-cu118
 	docker push ${DOCKER_IMAGE_NAME}:latest-py310-cu118
-	docker push ${DOCKER_IMAGE_NAME}:${NOS_VERSION_TAG}-py311-cu118
-	docker push ${DOCKER_IMAGE_NAME}:latest-py311-cu118
 
 agi-push-cu121:
-	docker push ${DOCKER_IMAGE_NAME}:${NOS_VERSION_TAG}-py38-cu121
-	docker push ${DOCKER_IMAGE_NAME}:latest-py38-cu121
 	docker push ${DOCKER_IMAGE_NAME}:${NOS_VERSION_TAG}-py310-cu121
 	docker push ${DOCKER_IMAGE_NAME}:latest-py310-cu121


### PR DESCRIPTION
 - `python3.11` is yet to be fully-tested

<!-- Thank you for your contribution! Please review https://github.com/autonomi-ai/nos/blob/main/docs/CONTRIBUTING.md before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Summary

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
