### PR TITLE
Support model configs w/o `model_cls` for model init on server start

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,6 @@ Perform real-time audio transcription using Whisper.
 
 <table>
 <tr>
-<td> Preview </td>
 <td> gRPC API ⚡ </td>
 <td> REST API </td>
 </tr>
@@ -190,7 +189,7 @@ from nos.client import Client
 
 client = Client("[::]:50051")
 
-model = client.Module("openai/whisper-large-v2")
+model = client.Module("openai/whisper-small.en")
 with client.UploadFile(Path("audio.wav")) as remote_path:
   response = model(path=remote_path)
 # {"chunks": ...}
@@ -204,7 +203,7 @@ curl \
 -X POST http://localhost:8000/v1/infer/file \
 -H 'accept: application/json' \
 -H 'Content-Type: multipart/form-data' \
--F 'model_id=openai/whisper-large-v2' \
+-F 'model_id=openai/whisper-small.en' \
 -F 'file=@audio.wav'
 ```
 

--- a/examples/tutorials/04-multiple-models/serve.yaml
+++ b/examples/tutorials/04-multiple-models/serve.yaml
@@ -7,6 +7,8 @@ images:
 models:
   TinyLlama/TinyLlama-1.1B-Chat-v1.0:
     runtime_env: custom-gpu
+    # TOFIX (spillai): Currently, pre-defined models cannot
+    # be deployed with overridden resource specification.
     deployment:
       resources:
         device: auto
@@ -14,6 +16,8 @@ models:
 
   distil-whisper/distil-small.en:
     runtime_env: custom-gpu
+    # TOFIX (spillai): Currently, pre-defined models cannot
+    # be deployed with overridden resource specification.
     deployment:
       resources:
         device: auto

--- a/examples/tutorials/04-multiple-models/serve.yaml
+++ b/examples/tutorials/04-multiple-models/serve.yaml
@@ -1,0 +1,20 @@
+images:
+  custom-gpu:
+    base: autonomi/nos:latest-gpu
+    env:
+      NOS_MAX_CONCURRENT_MODELS: 2
+
+models:
+  TinyLlama/TinyLlama-1.1B-Chat-v1.0:
+    runtime_env: custom-gpu
+    deployment:
+      resources:
+        device: auto
+        device_memory: 3Gi
+
+  distil-whisper/distil-small.en:
+    runtime_env: custom-gpu
+    deployment:
+      resources:
+        device: auto
+        device_memory: 8Gi

--- a/examples/tutorials/05-serving-with-docker/README.md
+++ b/examples/tutorials/05-serving-with-docker/README.md
@@ -1,0 +1,87 @@
+# Serving with `docker` and `docker-compose`
+
+This tutorial shows how to serve the NOS server directly with `docker` or `docker-compose`.
+
+## Serving with `docker`
+
+To run the NOS gRPC server with `docker` simply run:
+
+For CPU:
+```sh
+docker run --rm \
+    -e NOS_HOME=/app/.nos \
+    -v $(HOME)/.nos:/app/.nos \
+    -v /dev/shm:/dev/shm \
+    -p 50051:50051 \
+    autonomi/nos:latest-cpu
+```
+
+For running the GPU server, you need to install `nvidia-docker` and run the following command:
+```sh
+docker run --rm \
+    --name nos-grpc-server \
+    --gpus all \
+    -e NOS_HOME=/app/.nos \
+    -v $(HOME)/.nos:/app/.nos \
+    -v /dev/shm:/dev/shm \
+    -p 50051:50051 \
+    autonomi/nos:latest-gpu
+```
+
+
+## Serving with `docker-compose`
+
+To run the NOS gRPC server and the HTTP gateway with `docker-compose` simply run:
+
+```sh
+docker-compose up -f docker-compose.yml
+```
+
+You should now see the logs both from the server and the gateway.
+
+```bash
+(nos-py38) tutorials/05-serving-with-docker desktop [ docker compose -f docker-compose.yml up
+[+] Running 2/2
+ ✔ Container 05-serving-with-docker-nos-grpc-server-1   Created                                                                                                                                                0.0s
+ ✔ Container 05-serving-with-docker-nos-http-gateway-1  Recreated                                                                                                                                              0.0s
+Attaching to 05-serving-with-docker-nos-grpc-server-1, 05-serving-with-docker-nos-http-gateway-1
+05-serving-with-docker-nos-grpc-server-1   | Starting server with OMP_NUM_THREADS=64...
+05-serving-with-docker-nos-http-gateway-1  | WARNING:  Current configuration will not reload as not all conditions are met, please refer to documentation.
+05-serving-with-docker-nos-grpc-server-1   |  ✓ InferenceExecutor :: Connected to backend.
+05-serving-with-docker-nos-grpc-server-1   |  ✓ Starting gRPC server on [::]:50051
+05-serving-with-docker-nos-grpc-server-1   |  ✓ InferenceService :: Deployment complete (elapsed=0.0s)
+05-serving-with-docker-nos-http-gateway-1  | INFO:     Started server process [1]
+05-serving-with-docker-nos-http-gateway-1  | INFO:     Waiting for application startup.
+05-serving-with-docker-nos-http-gateway-1  | INFO:     Application startup complete.
+05-serving-with-docker-nos-http-gateway-1  | INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
+```
+
+The HTTP gateway service (`nos-http-gateway`) in the `docker-compose.yml` file simply forwards the HTTP requests to the gRPC server (`nos-grpc-server`). This is especially useful when exposing the server via a REST API.
+
+Here's the full `docker-compose.yml` file:
+
+```yaml
+{% include './docker-compose.yml' %}
+```
+
+## Testing the server
+
+To test the server's health, you can simply use `curl`:
+
+```sh
+curl -X "GET" "http://localhost:8000/v1/health" -H "accept: application/json"
+```
+
+You should see the following response:
+```sh
+{"status":"ok"}
+```
+
+You can now try one of the many requests showcased in the main [README](../../../README.md#what-can-nos-do).
+
+## Debugging the server
+
+ - **Running on CPUs:** You can remove the `deploy` section from the `docker-compose.yml` file to run the server without GPU capabilities.
+ - **Running on GPUs:** Make sure you have `nvidia-docker` installed and that you have the latest NVIDIA drivers installed on your machine. You can check the NVIDIA drivers version by running `nvidia-smi` on your terminal. If you don't have `nvidia-docker` installed, you can follow the instructions [here](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker).
+ - **Running on MacOS:** You can run the server on MacOS by removing the `deploy` section from the `docker-compose.yml` file.
+ - **Enabling debug logs:** You can enable debug logs on both the docker services by setting the `NOS_LOGGING_LEVEL` environment variable to `DEBUG` in the `docker-compose.yml` file. This should provide you with more information on what's happening under the hood.

--- a/examples/tutorials/05-serving-with-docker/docker-compose.yml
+++ b/examples/tutorials/05-serving-with-docker/docker-compose.yml
@@ -1,0 +1,38 @@
+version: "3.8"
+
+services:
+  nos-http-gateway:
+    image: autonomi/nos:latest-gpu
+    command: nos-http-server --host 0.0.0.0 --port 8000 --workers 1
+    environment:
+      - NOS_HOME=/app/.nos
+      - NOS_LOGGING_LEVEL=INFO
+      - NOS_GRPC_HOST=nos-grpc-server
+      - NOS_HTTP_ENV=dev
+    volumes:
+      - ~/.nosd:/app/.nos
+      - /dev/shm:/dev/shm
+    ports:
+      - 8000:8000
+    ipc: host
+    depends_on:
+      - nos-grpc-server
+
+  nos-grpc-server:
+    image: autonomi/nos:latest-gpu
+    environment:
+      - NOS_HOME=/app/.nos
+      - NOS_LOGGING_LEVEL=INFO
+    volumes:
+      - ~/.nosd:/app/.nos
+      - /dev/shm:/dev/shm
+    ports:
+      - 50051:50051
+    ipc: host
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]
+        limits:
+          memory: 12G

--- a/nos/cli/serve.py
+++ b/nos/cli/serve.py
@@ -277,8 +277,6 @@ def _serve(
         config = AGIPackConfig.load_yaml(config_filename)
 
         # Add the current working directory to the config `add`
-        # and include the NOS_HUB_CATALOG_PATH environment variable
-        # to the config `env`.
         # Note (spillai): The current working directory is added to /app/serve/<basedir>
         config_basename: Path = Path(config_filename).name
         container_config_path: Path = container_sandbox_path / config_basename
@@ -288,7 +286,6 @@ def _serve(
             # Add the sandbox directory to the PYTHONPATH so that
             # we can import the models via "from <sandbox_name>.models.model import X"
             image_config.env["PYTHONPATH"] = f"$PYTHONPATH:{SANDBOX_DIR}"
-            image_config.env["NOS_HUB_CATALOG_PATH"] = f"$NOS_HUB_CATALOG_PATH:{str(container_config_path)}"
 
         # Render the dockerfiles
         # agipack is responsible for the "images" sections

--- a/nos/test/test_data/hub/custom_model/config-malformed-model-cls.yaml
+++ b/nos/test/test_data/hub/custom_model/config-malformed-model-cls.yaml
@@ -1,5 +1,5 @@
 models:
-  custom-model:
+  custom-model-with-malformed-model-cls:
     model_path: models/model.py
     model_cls: _CustomModel
     default_method: __call__

--- a/nos/test/test_data/hub/custom_model/config-malformed-model-method.yaml
+++ b/nos/test/test_data/hub/custom_model/config-malformed-model-method.yaml
@@ -1,5 +1,5 @@
 models:
-  custom-model:
+  custom-model-with-malformed-model-method:
     model_path: models/model.py
     model_cls: CustomModel
     default_method: ___call__

--- a/nos/test/test_data/hub/custom_model/config-malformed-model-path.yaml
+++ b/nos/test/test_data/hub/custom_model/config-malformed-model-path.yaml
@@ -1,5 +1,5 @@
 models:
-  custom-model:
+  custom-model-with-malformed-model-path:
     model_path: models/_model.py
     model_cls: CustomModel
     default_method: __call__

--- a/nos/test/test_data/hub/custom_model/config-with-existing-model-id.yaml
+++ b/nos/test/test_data/hub/custom_model/config-with-existing-model-id.yaml
@@ -1,0 +1,15 @@
+# Here, we are testing the case where the model_id already exists in the hub.
+# In this case, the model_cls is not required, and instead we expect the server
+# to deploy the relevant number of replicas of the existing model.
+images:
+  gpu:
+    base: autonomi/nos:latest-gpu
+
+models:
+  noop/process-images:
+    runtime_env: gpu
+    deployment:
+      resources:
+        device: auto
+        device_memory: 1Gi
+      num_replicas: 2

--- a/nos/test/test_data/hub/custom_model/config-with-replicas.yaml
+++ b/nos/test/test_data/hub/custom_model/config-with-replicas.yaml
@@ -4,7 +4,7 @@ images:
     workdir: /app/serve
 
 models:
-  custom/custom-model-a:
+  custom/custom-model-a-with-replicas:
     runtime_env: gpu
     model_cls: CustomModel
     model_path: models/model.py
@@ -17,7 +17,7 @@ models:
         device_memory: 1Gi
       num_replicas: 2
 
-  custom/custom-model-b:
+  custom/custom-model-b-with-replicas:
     runtime_env: gpu
     model_cls: CustomModel
     model_path: models/model.py

--- a/tests/hub/test_hub.py
+++ b/tests/hub/test_hub.py
@@ -23,6 +23,10 @@ def test_hub_list():
     assert isinstance(model_names[0], str)
     assert len(model_names) > 0, "No models found in the registry."
 
+    for model_name in model_names:
+        hub_instance: Hub = Hub.get()
+        assert model_name in hub_instance
+
 
 def test_hub_load_spec_all():
     """Load all model specs from the hub."""
@@ -109,6 +113,7 @@ def test_hub_register_from_yaml():
     for yaml in [
         NOS_TEST_DATA_DIR / "hub/custom_model/config.yaml",
         NOS_TEST_DATA_DIR / "hub/custom_model/config-alternate-init-kwargs.yaml",
+        NOS_TEST_DATA_DIR / "hub/custom_model/config-with-existing-model-id.yaml",
     ]:
         Hub.register_from_yaml(yaml)
 
@@ -124,9 +129,8 @@ def test_hub_register_from_yaml():
         NOS_TEST_DATA_DIR / "hub/custom_model/config-malformed-model-path.yaml",
         NOS_TEST_DATA_DIR / "hub/custom_model/config-malformed-model-method.yaml",
     ]:
-
+        logger.debug(f"Loading model spec from malformed YAML: {yaml}")
         with pytest.raises(Exception):
-            logger.debug(f"Loading model spec from malformed YAML: {yaml}")
             Hub.register_from_yaml(yaml)
 
     logger.enable("nos")


### PR DESCRIPTION
## Summary
- Added tutorials for serving models with docker and docker compose

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [ ] `make lint`: I've run `make lint` to lint the changes in this PR.
- [ ] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
