### PR TITLE
New `inf2` runtime support with `nos serve up`

### DIFF
--- a/nos/cli/serve.py
+++ b/nos/cli/serve.py
@@ -38,8 +38,14 @@ class ServeOptions:
     image: str
     """Image name to use for the server."""
 
-    gpu: bool = field(default=False)
-    """Whether to use GPU for the server."""
+    runtime: str = field(default="cpu")
+    """Runtime environment to use for the server."""
+
+    devices: List[str] = field(default_factory=list)
+    """Devices to use for the server.
+
+    For inf2: ["/dev/neuron0", "/dev/neuron1", ...]
+    """
 
     http: bool = field(default=False)
     """Whether to use HTTP for the server."""
@@ -236,9 +242,10 @@ def _serve(
 
     # Get the runtime environment
     # Determine runtime from system
+    devices = InferenceServiceRuntime.devices()
     if runtime == "auto":
         runtime = InferenceServiceRuntime.detect()
-        logger.debug(f"Auto-detected system runtime: {runtime}")
+        logger.debug(f"Auto-detected system runtime: {runtime}, devices: {devices}")
     else:
         if runtime not in InferenceServiceRuntime.configs:
             raise ValueError(
@@ -382,7 +389,8 @@ def _serve(
     options = ServeOptions(
         config=container_config_path,
         image=image_name,
-        gpu=runtime == "gpu",
+        runtime=runtime,
+        devices=devices,
         http=http,
         http_host=http_host,
         http_port=http_port,

--- a/nos/cli/templates/docker-compose.serve.yml.j2
+++ b/nos/cli/templates/docker-compose.serve.yml.j2
@@ -57,10 +57,18 @@ services:
     ports:
       - 50051:50051
     ipc: host
-{%- if gpu %}
+{%- if runtime == 'gpu' %}
     deploy:
       resources:
         reservations:
           devices:
             - capabilities: [gpu]
+{% endif %}
+{%- if runtime == 'inf2' %}
+    {%- if devices|length > 0 %}
+    devices:
+    {%- for device in devices %}
+      - {{ device }}
+    {%- endfor %}
+    {%- endif %}
 {% endif %}

--- a/nos/server/_runtime.py
+++ b/nos/server/_runtime.py
@@ -192,6 +192,18 @@ class InferenceServiceRuntime:
             return "cpu"
 
     @staticmethod
+    def devices() -> List[str]:
+        """Auto-detect devices to use."""
+        from nos.common.system import has_gpu, is_aws_inf2
+
+        if is_aws_inf2():
+            return [str(p) for p in Path("/dev/").glob("neuron*")]
+        elif has_gpu():
+            return []
+        else:
+            return []
+
+    @staticmethod
     def list(**kwargs) -> List[docker.models.containers.Container]:
         """List running docker containers."""
         containers = DockerRuntime.get().list(**kwargs)

--- a/tests/server/test_inference_service_runtime.py
+++ b/tests/server/test_inference_service_runtime.py
@@ -90,6 +90,11 @@ def test_inference_service_runtime_utils():
     assert runtime == "gpu" if has_gpu() else "cpu", "Invalid runtime detected."
     assert InferenceServiceRuntime.list() is not None
 
+    devices = InferenceServiceRuntime.devices()
+    assert devices is not None
+    assert isinstance(devices, list)
+    assert len(devices) >= 0, "Invalid number of devices detected."
+
 
 def test_inference_service_runtime_cpu(inference_service_runtime_cpu):  # noqa: F811
     assert inference_service_runtime_cpu is not None


### PR DESCRIPTION
## Summary

This allows the user to run `nos serve up -c <serve.yaml>` and automatically run on `inf2` environments
 - added `inf2` device type in `serve.yml.j2` template
 - added `devices` field to programmatically determine number of neuron devices at startup

## Related issues

<!-- For example: "Closes #1234" -->

## Checks

- [x] `make lint`: I've run `make lint` to lint the changes in this PR.
- [x] `make test`: I've made sure the tests (`make test-cpu` or `make test`) are passing.
- Additional tests:
   - [ ] Benchmark tests (when contributing new models)
   - [ ] GPU/HW tests
